### PR TITLE
Oppdater Sanity frå v3.16.4 til v3.22.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # poao-endringslogg-sanity
 
 Sanity-oppsett for PO arbeidsoppfølgings endringslogg.
-Innholder er tilgjengelig på [https://endringslogg.sanity.studio/production/desk](https://endringslogg.sanity.studio/production/desk)
+Innholder er tilgjengelig på [https://endringslogg.sanity.studio/production/structure](https://endringslogg.sanity.studio/production/structure)
 
 ## Bygg og deploy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,64 +9,75 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.20.0",
-        "@sanity/vision": "3.20.0",
+        "@sanity/cli": "3.22.2",
+        "@sanity/vision": "3.22.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "4.11.0",
-        "sanity": "3.20.0",
+        "sanity": "3.22.2",
         "short-uuid": "4.2.2",
         "styled-components": "5.3.11"
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
+      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.15.tgz",
-      "integrity": "sha512-PtZqMmgRrvj8ruoEOIwVA3yoF91O+Hgw9o7DAUTNBA6Mo2jpu31clx9a7Nz/9JznqetTR6zwfC4L3LAjKQXUwA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.15",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.15",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -89,14 +100,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
+      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
       "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.26.2",
+        "@babel/types": "^7.26.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -114,13 +126,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -136,58 +148,26 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.15.tgz",
-      "integrity": "sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.15"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -197,89 +177,56 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -288,11 +235,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.22.5.tgz",
-      "integrity": "sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
+      "integrity": "sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -302,11 +249,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.22.5.tgz",
-      "integrity": "sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz",
+      "integrity": "sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -316,42 +263,39 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
-      "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
+      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
       "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/code-frame": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.25.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -360,13 +304,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -940,46 +883,46 @@
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@juggle/resize-observer": {
@@ -1136,25 +1079,27 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.20.0.tgz",
-      "integrity": "sha512-h8XN+9Q3IbUQAUVLqcTb4lu1GaGog0eSba/qafzsfP/cUBhu5X3V8XmOhOUxnm0KYh/G7rOiyiTFlM8QH5PE6Q==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.22.2.tgz",
+      "integrity": "sha512-9X3euFnXmzlsKrQmn7mxyMEvjZ31a1Yosws8nJuSL2hZtOEXmTibgMBu3FZs2nJQ2v+UJM/jhXZHOjd97h/wBA==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.20.0.tgz",
-      "integrity": "sha512-1rvEw4owMSsqeq+5R5hb8moDTrMtrktx2L6p/PWJu2Sb+Iwctm51G+XOTjH9On0o3jhLQPG0BPLE6rXEUlcPyA==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.22.2.tgz",
+      "integrity": "sha512-QgvCQVIiES4CM1xH39eNHnbgKXaoeXk2Cb/4g/hlyrxWDK3zHgbgSwAhnQegRSqeC4Ifj1XeFEylLxk6P9EOfw==",
       "dependencies": {
-        "@babel/traverse": "^7.19.0",
+        "@babel/traverse": "^7.23.5",
+        "@sanity/telemetry": "^0.7.3",
         "chalk": "^4.1.2",
-        "esbuild": "^0.19.0",
+        "esbuild": "^0.19.8",
         "esbuild-register": "^3.4.1",
         "get-it": "^8.4.4",
         "golden-fleece": "^1.0.9",
+        "node-machine-id": "^1.1.12",
         "pkg-dir": "^5.0.0"
       },
       "bin": {
@@ -1247,9 +1192,9 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.20.0.tgz",
-      "integrity": "sha512-0VV3gIK5SEWCQ3oINZECqGGfRNuMN0Rk3wOENaZG/n44RRf7F5yQy9wABBXiRsODDPyHu5IUOfqbE0ozT610/Q==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.22.2.tgz",
+      "integrity": "sha512-n9tbvW64niQSvegYPdBzMFAOtvHvN9n4Ufiqn1pnFMqivb5LnC/YJbJoO6nAmTp+pdH1N5gQxZbSowQZEqVdQg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -1277,9 +1222,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.20.0.tgz",
-      "integrity": "sha512-D3Qp8DZxi5fTGeySH7hRA3TsU13UVwjTfWt8id+jfjZ5a4dJYy7Xd/skfT1srHIbI3R/7RtU92l3Roozpg8PaA==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.22.2.tgz",
+      "integrity": "sha512-Wx2lKRhrKgw6ggH39+Zr73dRmlPBEUDAvE4pxyH9/LJGcCODyE0zRTsywswCYnAd7w67Zf3tqpkL1Ch/vGR/pA==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -1308,17 +1253,17 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/groq-store": {
-      "version": "5.0.1-experimental",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.0.1-experimental.tgz",
-      "integrity": "sha512-3qKQVxQW7j0n4DbmiFzEhC9jLK51u2F0d1xGYUWn0dUU5wrot2BfdlINGdCFze9FjvoPrOkihD6rc51Gfnk2xg==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.3.5.tgz",
+      "integrity": "sha512-djrCQvrWwK2By+/zoqPR+oR2vRT94OUptCR8zHTVjpKkSrBd3/fJAyFfB0CBj90tdz4PSGcYFnRFIslsEJLTPA==",
       "dependencies": {
-        "mnemonist": "0.39.5"
+        "mnemonist": "0.39.6"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.8.6"
+        "@sanity/client": "^6.10.0"
       }
     },
     "node_modules/@sanity/icons": {
@@ -1341,13 +1286,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.20.0.tgz",
-      "integrity": "sha512-fFkl+AgvRL5Bcl9OLhyXmxh02+zLZYI9BxtxUjPB+mz7kk3LdaxgEo+3pKQaawv/USQl8d/2IkHSa1ofX0LFzQ==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.22.2.tgz",
+      "integrity": "sha512-zT3zLgSaTR7GI0mF36aRUZJrB3RIOhGCoth5v278icCTkVHvr8A3/KZjOCXu4EOS23eBmLS1oGrlFtc7VpfqRg==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.20.0",
+        "@sanity/mutator": "3.22.2",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -1389,9 +1334,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.20.0.tgz",
-      "integrity": "sha512-BGdFRAWqDpB3iriBYq5SZCnF1B+u1/pR4URuHOIxRraRbO7MXDhVbpe8MBEo3CPCTakCP+FfdF+WhznMc8bPEQ==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.22.2.tgz",
+      "integrity": "sha512-U1GFZ5vmcU08gsqkuwqLAufQHR3wU8DGEfjo6BGHvuKXi3RMt3nHLDRn/EL0RWL/z0Bdz+zExoruXIYAU2EjRQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -1408,14 +1353,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.20.0.tgz",
-      "integrity": "sha512-Udl4K3uGmybnZSbCunNC2d6YN+ELY94ron4J5zSuXV5ULD4paKgU8HkOdOJtN0AfLmgd0OBcn8GOtrjXd9ZtHQ==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.22.2.tgz",
+      "integrity": "sha512-DQwCMcAUoFXQ3aYYcdghmHKht58H1aO/5SeCuqBNf8+wpq+B4gl4UiX08mcxHUSyxwMWfpGCuLhn81Z4pAIdwg==",
       "dependencies": {
-        "@sanity/block-tools": "3.20.0",
-        "@sanity/schema": "3.20.0",
-        "@sanity/types": "3.20.0",
-        "@sanity/util": "3.20.0",
+        "@sanity/block-tools": "3.22.2",
+        "@sanity/schema": "3.22.2",
+        "@sanity/types": "3.22.2",
+        "@sanity/util": "3.22.2",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -1466,9 +1411,9 @@
       "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
     "node_modules/@sanity/preview-url-secret": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-1.0.2.tgz",
-      "integrity": "sha512-+Im3HdXdFZk0ZCYbeeDUC7ns30NijcBS7ldsxOPNn3+NTmZ5Cw8VvHZ3OLOnA/6ddhR4T2y+CLwsduQz09PHTg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-1.6.21.tgz",
+      "integrity": "sha512-ZAIT4I5Nrsax+RBQVhSBY4PnnHgaI+eybSd5aHhjZi97+ziMTtTLnL1Hsg+ViLtPqJWwX0GiB0l8nSfGAt7+QA==",
       "dependencies": {
         "@sanity/uuid": "3.0.2"
       },
@@ -1476,16 +1421,16 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.8.6"
+        "@sanity/client": "^6.21.3"
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.20.0.tgz",
-      "integrity": "sha512-eYsG/L+k1l6fZcZ5XTETjisxuCDNKf0Td0ywdloq4AvVpXCDYDmsYw81UHzvoviuWZ7zejo1lvs5LnIeOl1gzQ==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.22.2.tgz",
+      "integrity": "sha512-/+cP98tiflrdZlzIcJinNCfpO2oMF3UH1pg32aKK0VfSyuaJGaVk6Afqcp9ZVAemxadV54lyx9A/WbgBM7aRxA==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.20.0",
+        "@sanity/types": "3.22.2",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1493,12 +1438,28 @@
         "object-inspect": "^1.6.0"
       }
     },
-    "node_modules/@sanity/types": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.20.0.tgz",
-      "integrity": "sha512-EhSTVaG91yYAayMg11N8rm35vzOvwMWeBRv3mia1cIf/KfXnlClCnSDiqLkkdrdSq6N+G6gmjcpSP/zNd9e0gg==",
+    "node_modules/@sanity/telemetry": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@sanity/telemetry/-/telemetry-0.7.9.tgz",
+      "integrity": "sha512-TBBRK2SUwiNND+ZJPwdWSu8tbEjdIz7UjagmCCBBWcfXtDKXXlWawC/DOEWuI4Q+WcA5OWLDjboxZT4ApWjVbw==",
       "dependencies": {
-        "@sanity/client": "^6.8.6",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "typeid-js": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2 || >=19.0.0-rc"
+      }
+    },
+    "node_modules/@sanity/types": {
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.22.2.tgz",
+      "integrity": "sha512-AdT0EGraxCx1ljb0kOo9l1yNyhnIPTES2/I8YbU3jJk+ghUayGl2jzbZyDbvhYMCf7VL0oH73/zBm8eeERIDAQ==",
+      "dependencies": {
+        "@sanity/client": "^6.10.0",
         "@types/react": "^18.0.25"
       }
     },
@@ -1525,11 +1486,11 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.20.0.tgz",
-      "integrity": "sha512-9/NOG+fIn0N3Jv6G39ldjW+sX3Cz5rncw3G+ufrOIU4BjDPfwzAGqL+paQWKmPm/RiTU/AaVn62nVfkqj33dAA==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.22.2.tgz",
+      "integrity": "sha512-yUyWhJmH1uBVdvjukqabd0lEpu6p71SehdJWoxaa3/UY9FGVibEhduU0/dTfwydCi/2mpXFX+9y93KfqHxuqrw==",
       "dependencies": {
-        "@sanity/types": "3.20.0",
+        "@sanity/types": "3.22.2",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -1547,9 +1508,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.20.0.tgz",
-      "integrity": "sha512-QNgr4Ihrdwo06J4ch57rJfAdFFYAYEJBBaBqNIS8e3DDrtvp8BZLjKj8pUVxNBqpFQ8+eB1H+ZbqPjvPOmyGXg==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.22.2.tgz",
+      "integrity": "sha512-3ELf+bvG8V+209SgJZ+1rUjfVasOCUrivmW6NzZOMBYyuXrTatVZCRvb4+r+Q3eJ5ru2iLxlCi/OJhm4AZVeVQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1599,12 +1560,41 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "engines": {
-        "node": ">= 10"
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/event-source-polyfill": {
@@ -1790,64 +1780,32 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.0.4.tgz",
-      "integrity": "sha512-7wU921ABnNYkETiMaZy7XqpueMnpu5VxvVps13MjmCo+utBdD79sZzrApHawHtVX66cCJQQTXFcjH0y9dSUK8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.3.tgz",
+      "integrity": "sha512-NooDe9GpHGqNns1i8XDERg0Vsg5SSYRhRxxyTGogUdkdNt47jal+fbuYi+Yfq6pzRCKXyoPcWisfxE6RIM3GKA==",
       "dependencies": {
-        "@babel/core": "^7.22.9",
-        "@babel/plugin-transform-react-jsx-self": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.22.5",
-        "react-refresh": "^0.14.0"
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.14.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0"
-      }
-    },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
-    "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "engines": {
-        "node": ">=0.4.0"
+        "vite": "^4.2.0 || ^5.0.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ansi-regex": {
@@ -2006,6 +1964,14 @@
         }
       ]
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2066,9 +2032,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2084,10 +2050,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2146,9 +2112,9 @@
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001525",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
-      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
+      "version": "1.0.30001680",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -2402,9 +2368,9 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -2513,26 +2479,33 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
-    },
-    "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    "node_modules/cssstyle": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+      "dependencies": {
+        "rrweb-cssom": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -2550,16 +2523,15 @@
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/dataloader": {
@@ -2622,11 +2594,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -2676,17 +2643,6 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
@@ -2723,9 +2679,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.508",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.508.tgz",
-      "integrity": "sha512-FFa8QKjQK/A5QuFr2167myhMesGrhlOBD+3cYNxO9/S4XzHEXesyTD/1/xF644gC8buFPz3ca6G1LOQD0tZrrg=="
+      "version": "1.5.56",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz",
+      "integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2808,9 +2764,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -2821,55 +2777,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/event-source-polyfill": {
@@ -2928,11 +2835,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -3391,45 +3293,74 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dependencies": {
-        "whatwg-encoding": "^2.0.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dependencies": {
+        "void-elements": "3.1.0"
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-list": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-list/-/humanize-list-1.0.1.tgz",
       "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA=="
+    },
+    "node_modules/i18next": {
+      "version": "23.16.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.5.tgz",
+      "integrity": "sha512-KTlhE3EP9x6pPTAW7dy0WKIhoCpfOGhRQlO+jttQLgzVaoOjWwBWramu7Pp0i+8wDNduuzXfe3kkVbzrKyrbTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -3741,42 +3672,37 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
       "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
         "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^2.11.2"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -3793,14 +3719,14 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-lexer": {
@@ -3846,18 +3772,6 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3967,6 +3881,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
       "integrity": "sha512-QBJSFpsedXUl/Lgs4ySdB2XCzUEcJ3ujpbagdZCkRaYIaC0kFnID8jhc84KEiVv6dNFtIrmW7bqow0lDxgJi6A=="
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/memoize-resolver": {
       "version": "1.0.0",
@@ -4090,9 +4009,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mnemonist": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
-      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
+      "integrity": "sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==",
       "dependencies": {
         "obliterator": "^2.0.1"
       }
@@ -4137,10 +4056,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-machine-id": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
+    },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -4179,11 +4103,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4261,22 +4180,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-finally": {
@@ -4479,9 +4382,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4590,9 +4493,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4609,19 +4512,11 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-ms": {
@@ -4740,9 +4635,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -4852,6 +4747,27 @@
         }
       }
     },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
@@ -4884,9 +4800,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5017,14 +4933,22 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5097,6 +5021,11 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5157,9 +5086,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.20.0.tgz",
-      "integrity": "sha512-mGe9+pn3Y7HrIT5mgCwzEv4OHGJ6C9YlovyQE7gR5XY1p9YJNPonbWUOfhM7D3dVMfG0/OuilH1MmTc1bGnb8w==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.22.2.tgz",
+      "integrity": "sha512-1IY7pw2rYxch4pod/4tyLQMpF8W49XgdaDnvcrifaNtA2AbtbR3YvxAvxXzsrCgVvZ1HeYfYSVPRj15PUZOuzQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -5170,26 +5099,27 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.20.0",
-        "@sanity/cli": "3.20.0",
-        "@sanity/client": "^6.8.6",
+        "@sanity/block-tools": "3.22.2",
+        "@sanity/cli": "3.22.2",
+        "@sanity/client": "^6.10.0",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.20.0",
+        "@sanity/diff": "3.22.2",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.20.0",
+        "@sanity/export": "3.22.2",
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/icons": "^2.6.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.20.0",
+        "@sanity/import": "3.22.2",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.20.0",
-        "@sanity/portable-text-editor": "3.20.0",
-        "@sanity/presentation": "1.0.3",
-        "@sanity/schema": "3.20.0",
-        "@sanity/types": "3.20.0",
+        "@sanity/mutator": "3.22.2",
+        "@sanity/portable-text-editor": "3.22.2",
+        "@sanity/presentation": "1.2.1",
+        "@sanity/schema": "3.22.2",
+        "@sanity/telemetry": "^0.7.3",
+        "@sanity/types": "3.22.2",
         "@sanity/ui": "^1.9.3",
-        "@sanity/util": "3.20.0",
+        "@sanity/util": "3.22.2",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
@@ -5198,7 +5128,7 @@
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
         "@types/use-sync-external-store": "^0.0.5",
-        "@vitejs/plugin-react": "^4.0.0",
+        "@vitejs/plugin-react": "^4.2.0",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
         "classnames": "^2.2.5",
@@ -5209,7 +5139,7 @@
         "dataloader": "^2.1.0",
         "date-fns": "^2.26.1",
         "debug": "^3.2.7",
-        "esbuild": "^0.19.0",
+        "esbuild": "^0.19.8",
         "esbuild-register": "^3.4.1",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
@@ -5219,9 +5149,10 @@
         "groq-js": "^1.1.12",
         "hashlru": "^2.3.0",
         "history": "^5.3.0",
+        "i18next": "^23.2.7",
         "import-fresh": "^3.3.0",
         "is-hotkey": "^0.1.6",
-        "jsdom": "^20.0.0",
+        "jsdom": "^23.0.1",
         "jsdom-global": "^3.0.2",
         "json-lexer": "^1.2.0",
         "json-reduce": "^3.0.0",
@@ -5243,6 +5174,7 @@
         "react-copy-to-clipboard": "^5.0.4",
         "react-fast-compare": "^3.2.0",
         "react-focus-lock": "^2.8.1",
+        "react-i18next": "^13.0.1",
         "react-is": "^18.2.0",
         "react-refractor": "^2.1.6",
         "react-rx": "^2.1.3",
@@ -5262,7 +5194,7 @@
         "use-device-pixel-ratio": "^1.1.0",
         "use-hot-module-reload": "^1.0.1",
         "use-sync-external-store": "^1.2.0",
-        "vite": "^4.4.4",
+        "vite": "^4.5.0",
         "yargs": "^17.3.0"
       },
       "bin": {
@@ -5289,16 +5221,16 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/presentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.0.3.tgz",
-      "integrity": "sha512-1+vKL9HPRV5ew9rzU4Gorgcw1OLhTVTeoYjy4zJjs41w9rNCFnBNd5GVvy6qYLiyAG47h8VtOwZG95wm27bJxA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.2.1.tgz",
+      "integrity": "sha512-Bfb9rLcJu9DLBn1JDWZwkPfS8ItlJZoWPSdXnzQKPE4/RpNUX26xPhCkjxSH3Thg/ALMLNv3qZVHTPbFqqv1Tg==",
       "dependencies": {
-        "@sanity/groq-store": "5.0.1-experimental",
-        "@sanity/icons": "^2.7.0",
-        "@sanity/preview-url-secret": "1.0.2",
+        "@sanity/groq-store": "5.3.5",
+        "@sanity/icons": "^2.8.0",
+        "@sanity/preview-url-secret": "^1.3.5",
         "@sanity/ui": "^1.9.3",
         "@types/lodash.isequal": "^4.5.8",
-        "framer-motion": "^10.16.5",
+        "framer-motion": "^10.16.16",
         "lodash.isequal": "^4.5.0",
         "mendoza": "3.0.3",
         "rxjs": "^7.8.1",
@@ -5308,11 +5240,25 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.8.6",
+        "@sanity/client": "^6.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sanity": "^3.19.3",
-        "styled-components": "^6.1.1"
+        "sanity": "^3.21.3",
+        "styled-components": "^5.2 || ^6.1.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "sanity": {
+          "optional": true
+        },
+        "styled-components": {
+          "optional": true
+        }
       }
     },
     "node_modules/sanity/node_modules/ansi-styles": {
@@ -5521,19 +5467,10 @@
         "tiny-warning": "^1.0.3"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5816,14 +5753,6 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5855,14 +5784,14 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -5879,17 +5808,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -5911,6 +5829,14 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typeid-js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/typeid-js/-/typeid-js-0.3.0.tgz",
+      "integrity": "sha512-A1EmvIWG6xwYRfHuYUjPltHqteZ1EiDG+HOmbIYXeHUVztmnGrPIfU9KIK1QC30x59ko0r4JsMlwzsALCyiB3Q==",
+      "dependencies": {
+        "uuidv7": "^0.4.4"
       }
     },
     "node_modules/unique-string": {
@@ -5963,9 +5889,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5981,8 +5907,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -6078,6 +6004,14 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuidv7": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-0.4.4.tgz",
+      "integrity": "sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -6088,9 +6022,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -6507,20 +6441,28 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
       "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dependencies": {
-        "xml-name-validator": "^4.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6532,34 +6474,34 @@
       }
     },
     "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -6574,14 +6516,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -6647,9 +6581,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6675,11 +6609,11 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xmlchars": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.19.3",
-        "@sanity/vision": "3.19.3",
+        "@sanity/cli": "3.20.0",
+        "@sanity/vision": "3.20.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "4.11.0",
-        "sanity": "3.19.3",
+        "sanity": "3.20.0",
         "short-uuid": "4.2.2",
         "styled-components": "5.3.11"
       }
@@ -1136,18 +1136,18 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.19.3.tgz",
-      "integrity": "sha512-m4+p8OXor+hufy8yd5ZcuJKFNb7zYAlNp77GQl6LV+6DcfFGxDGN+2R/5qwh1Fot9ufIiGRkRTl5aWYrd2PUVg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.20.0.tgz",
+      "integrity": "sha512-h8XN+9Q3IbUQAUVLqcTb4lu1GaGog0eSba/qafzsfP/cUBhu5X3V8XmOhOUxnm0KYh/G7rOiyiTFlM8QH5PE6Q==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.19.3.tgz",
-      "integrity": "sha512-DoekRfYh1ihJJ7Oeuju0kkpGnqas0xl5Yugu1JJ+snW/tRG8+0legigY0SHkjyPbJoFChvK1sKZE8xP12Cc7Fw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.20.0.tgz",
+      "integrity": "sha512-1rvEw4owMSsqeq+5R5hb8moDTrMtrktx2L6p/PWJu2Sb+Iwctm51G+XOTjH9On0o3jhLQPG0BPLE6rXEUlcPyA==",
       "dependencies": {
         "@babel/traverse": "^7.19.0",
         "chalk": "^4.1.2",
@@ -1247,9 +1247,9 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.19.3.tgz",
-      "integrity": "sha512-stzVGEBGUP4Gytkukad/zQJ8QOVXQjKwJzhbI5LnPcRgQI5bccAYYY9mJkPWkjIerolyo/4bc3qYB48RaQBVPg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.20.0.tgz",
+      "integrity": "sha512-0VV3gIK5SEWCQ3oINZECqGGfRNuMN0Rk3wOENaZG/n44RRf7F5yQy9wABBXiRsODDPyHu5IUOfqbE0ozT610/Q==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -1277,9 +1277,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.19.3.tgz",
-      "integrity": "sha512-DrDfHJS7oybIynKNiRthiqg4zJT/CzfgyydQXfkVUPquxjO629VeDXLDfvhvNLrF1ZqNZTtdrF6ngggfXoDZzw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.20.0.tgz",
+      "integrity": "sha512-D3Qp8DZxi5fTGeySH7hRA3TsU13UVwjTfWt8id+jfjZ5a4dJYy7Xd/skfT1srHIbI3R/7RtU92l3Roozpg8PaA==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -1307,6 +1307,20 @@
       "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-3.0.0.tgz",
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
+    "node_modules/@sanity/groq-store": {
+      "version": "5.0.1-experimental",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.0.1-experimental.tgz",
+      "integrity": "sha512-3qKQVxQW7j0n4DbmiFzEhC9jLK51u2F0d1xGYUWn0dUU5wrot2BfdlINGdCFze9FjvoPrOkihD6rc51Gfnk2xg==",
+      "dependencies": {
+        "mnemonist": "0.39.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.8.6"
+      }
+    },
     "node_modules/@sanity/icons": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.10.0.tgz",
@@ -1327,13 +1341,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.19.3.tgz",
-      "integrity": "sha512-9uXanchWewUVtMMVCFGWI3vhULb48LZBa+pq6AMDnqLcWl4+SmjGthx7gmUf2re8A2Fy6bl0H74uqAEMzCpLCg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.20.0.tgz",
+      "integrity": "sha512-fFkl+AgvRL5Bcl9OLhyXmxh02+zLZYI9BxtxUjPB+mz7kk3LdaxgEo+3pKQaawv/USQl8d/2IkHSa1ofX0LFzQ==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.19.3",
+        "@sanity/mutator": "3.20.0",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -1375,9 +1389,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.19.3.tgz",
-      "integrity": "sha512-BdTz4m5Q757/A024DrNJMtFaeRQYApX6yMAU5GyQjBH/NEF94ZXglZ9AiEgqZ7U+b9R6cAouCH/k4dsbJn0Sbg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.20.0.tgz",
+      "integrity": "sha512-BGdFRAWqDpB3iriBYq5SZCnF1B+u1/pR4URuHOIxRraRbO7MXDhVbpe8MBEo3CPCTakCP+FfdF+WhznMc8bPEQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -1394,14 +1408,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.19.3.tgz",
-      "integrity": "sha512-9a92Uv8RaIqIx98ODR/wmGBFqkxxII0MEySKs0Xh4OW/c/7k0Uax6CiZswOZtJqErMqQyfCiH5gf/uRSJmcbZQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.20.0.tgz",
+      "integrity": "sha512-Udl4K3uGmybnZSbCunNC2d6YN+ELY94ron4J5zSuXV5ULD4paKgU8HkOdOJtN0AfLmgd0OBcn8GOtrjXd9ZtHQ==",
       "dependencies": {
-        "@sanity/block-tools": "3.19.3",
-        "@sanity/schema": "3.19.3",
-        "@sanity/types": "3.19.3",
-        "@sanity/util": "3.19.3",
+        "@sanity/block-tools": "3.20.0",
+        "@sanity/schema": "3.20.0",
+        "@sanity/types": "3.20.0",
+        "@sanity/util": "3.20.0",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -1451,13 +1465,27 @@
       "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
       "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
+    "node_modules/@sanity/preview-url-secret": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-1.0.2.tgz",
+      "integrity": "sha512-+Im3HdXdFZk0ZCYbeeDUC7ns30NijcBS7ldsxOPNn3+NTmZ5Cw8VvHZ3OLOnA/6ddhR4T2y+CLwsduQz09PHTg==",
+      "dependencies": {
+        "@sanity/uuid": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.8.6"
+      }
+    },
     "node_modules/@sanity/schema": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.19.3.tgz",
-      "integrity": "sha512-KQfNuSRAPuRpft7H3X+L3rLtF8zjbIs/d/3jbrRZHqYPxhe1oTtqlf2X3En389Kym4DSSlQ625yZ/zmJYJDVIQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.20.0.tgz",
+      "integrity": "sha512-eYsG/L+k1l6fZcZ5XTETjisxuCDNKf0Td0ywdloq4AvVpXCDYDmsYw81UHzvoviuWZ7zejo1lvs5LnIeOl1gzQ==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.19.3",
+        "@sanity/types": "3.20.0",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1466,11 +1494,11 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.19.3.tgz",
-      "integrity": "sha512-yiAwDqn058GD4rGl7hGVNH21rqR5hQlk0LBLB2BX4qnrxrqZ30+xFHwjgRM8EYFN51VspEbtov2jQmCijlIOpg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.20.0.tgz",
+      "integrity": "sha512-EhSTVaG91yYAayMg11N8rm35vzOvwMWeBRv3mia1cIf/KfXnlClCnSDiqLkkdrdSq6N+G6gmjcpSP/zNd9e0gg==",
       "dependencies": {
-        "@sanity/client": "^6.8.5",
+        "@sanity/client": "^6.8.6",
         "@types/react": "^18.0.25"
       }
     },
@@ -1497,11 +1525,11 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.19.3.tgz",
-      "integrity": "sha512-70VE9Xy8DZS5hHatu54nhU/qv4orrelV7/C3M/EoXyhTTOcvUoWXTTKzasqBGSUNASxKkNX9GuGoj7tUtPWCVQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.20.0.tgz",
+      "integrity": "sha512-9/NOG+fIn0N3Jv6G39ldjW+sX3Cz5rncw3G+ufrOIU4BjDPfwzAGqL+paQWKmPm/RiTU/AaVn62nVfkqj33dAA==",
       "dependencies": {
-        "@sanity/types": "3.19.3",
+        "@sanity/types": "3.20.0",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -1519,9 +1547,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.19.3.tgz",
-      "integrity": "sha512-Bc3yhM8zMHakwxscNuz7PMG7+MvTreU6W97yX8+IuWBsdg4a6P5nOEgDvaPod6krCyGrr3f4MmwHWmLRqH9+Qw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.20.0.tgz",
+      "integrity": "sha512-QNgr4Ihrdwo06J4ch57rJfAdFFYAYEJBBaBqNIS8e3DDrtvp8BZLjKj8pUVxNBqpFQ8+eB1H+ZbqPjvPOmyGXg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1623,6 +1651,14 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
       "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -3860,6 +3896,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -3931,14 +3972,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/memoize-resolver/-/memoize-resolver-1.0.0.tgz",
       "integrity": "sha512-mXfNXte0RSWl0rEIsQhXutfM2R2Oa7UyKDD7XoZMEbKeucTRms04y5y41U8gLqPzRx7ViN/QyYnTR2TX/5tawA=="
-    },
-    "node_modules/mendoza": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.3.tgz",
-      "integrity": "sha512-xh0Angj7/kuLzJHglH7dVetoSyUt1/2wjmuugB0iBftteS6+xKvwC+bhs+IvF9tITdEdZpIl0XT5QLaL18A5dA==",
-      "engines": {
-        "node": ">=14.18"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -4056,6 +4089,14 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.5.tgz",
+      "integrity": "sha512-FPUtkhtJ0efmEFGpU14x7jGbTB+s18LrzRL2KgoWz9YvcY3cPomz8tih01GbHwnGk/OmkOKfqd/RAQoc8Lm7DQ==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/module-alias": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
@@ -4162,6 +4203,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
     },
     "node_modules/observable-callback": {
       "version": "1.0.2",
@@ -5111,9 +5157,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.19.3.tgz",
-      "integrity": "sha512-Lz8yynVaZZrtzGcPiWZlZ8wml8xBOnw9O4n/0Nq7dcSeg43kaGIHi0pUSFs3Ft0D7KkgT8fdGCoKN4HabDeZBA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.20.0.tgz",
+      "integrity": "sha512-mGe9+pn3Y7HrIT5mgCwzEv4OHGJ6C9YlovyQE7gR5XY1p9YJNPonbWUOfhM7D3dVMfG0/OuilH1MmTc1bGnb8w==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -5124,25 +5170,26 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.19.3",
-        "@sanity/cli": "3.19.3",
-        "@sanity/client": "^6.8.5",
+        "@sanity/block-tools": "3.20.0",
+        "@sanity/cli": "3.20.0",
+        "@sanity/client": "^6.8.6",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.19.3",
+        "@sanity/diff": "3.20.0",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.19.3",
+        "@sanity/export": "3.20.0",
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/icons": "^2.6.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.19.3",
+        "@sanity/import": "3.20.0",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.19.3",
-        "@sanity/portable-text-editor": "3.19.3",
-        "@sanity/schema": "3.19.3",
-        "@sanity/types": "3.19.3",
+        "@sanity/mutator": "3.20.0",
+        "@sanity/portable-text-editor": "3.20.0",
+        "@sanity/presentation": "1.0.3",
+        "@sanity/schema": "3.20.0",
+        "@sanity/types": "3.20.0",
         "@sanity/ui": "^1.9.3",
-        "@sanity/util": "3.19.3",
+        "@sanity/util": "3.20.0",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
@@ -5241,6 +5288,33 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/sanity/node_modules/@sanity/presentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.0.3.tgz",
+      "integrity": "sha512-1+vKL9HPRV5ew9rzU4Gorgcw1OLhTVTeoYjy4zJjs41w9rNCFnBNd5GVvy6qYLiyAG47h8VtOwZG95wm27bJxA==",
+      "dependencies": {
+        "@sanity/groq-store": "5.0.1-experimental",
+        "@sanity/icons": "^2.7.0",
+        "@sanity/preview-url-secret": "1.0.2",
+        "@sanity/ui": "^1.9.3",
+        "@types/lodash.isequal": "^4.5.8",
+        "framer-motion": "^10.16.5",
+        "lodash.isequal": "^4.5.0",
+        "mendoza": "3.0.3",
+        "rxjs": "^7.8.1",
+        "suspend-react": "0.1.3"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@sanity/client": "^6.8.6",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sanity": "^3.19.3",
+        "styled-components": "^6.1.1"
+      }
+    },
     "node_modules/sanity/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5300,6 +5374,14 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sanity/node_modules/mendoza": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.3.tgz",
+      "integrity": "sha512-xh0Angj7/kuLzJHglH7dVetoSyUt1/2wjmuugB0iBftteS6+xKvwC+bhs+IvF9tITdEdZpIl0XT5QLaL18A5dA==",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/sanity/node_modules/supports-color": {
@@ -5661,6 +5743,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.16.4",
-        "@sanity/vision": "3.16.4",
+        "@sanity/cli": "3.19.3",
+        "@sanity/vision": "3.19.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "4.11.0",
-        "sanity": "3.16.4",
+        "sanity": "3.19.3",
         "short-uuid": "4.2.2",
         "styled-components": "5.3.11"
       }
@@ -906,20 +906,20 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
-      "integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -1049,6 +1049,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@portabletext/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@portabletext/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-ZGHlvS+NvId9RSqnflN8xF2KVZgAgD399dK1GaycurnGNZGZYTd5nZmc8by1yL76Ar8n/dbVtouUDJIkO4Tupw==",
+      "dependencies": {
+        "@portabletext/toolkit": "^2.0.15",
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || >=19.0.0-rc"
+      }
+    },
+    "node_modules/@portabletext/toolkit": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@portabletext/toolkit/-/toolkit-2.0.16.tgz",
+      "integrity": "sha512-aBvnD8MscoAlEIuZBn0Aksd+oCuoMGFOT3CtHIgRBaac0Vu4YnnMUF45xo/B/T5vmwWcnDXoJEJdn+SKDg1m+A==",
+      "dependencies": {
+        "@portabletext/types": "^2.0.13"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@portabletext/types": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@portabletext/types/-/types-2.0.13.tgz",
+      "integrity": "sha512-5xk5MSyQU9CrDho3Rsguj38jhijhD36Mk8S6mZo3huv6PM+t4M/5kJN2KFIxgvt4ONpvOEs1pVIZAV0cL0Vi+Q==",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0 || >=18.0.0"
+      }
+    },
     "node_modules/@rexxars/react-json-inspector": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@rexxars/react-json-inspector/-/react-json-inspector-8.0.1.tgz",
@@ -1085,9 +1119,9 @@
       }
     },
     "node_modules/@sanity/asset-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-1.3.0.tgz",
-      "integrity": "sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-1.3.2.tgz",
+      "integrity": "sha512-dixN6MpMXsCEVh0Dr932cgZ4cU3Z2JnNOYBxjV+dgO6AnqVpNQTY+KgGMYlA1ca5zCztQI1VSk/MBCPSxihPqQ==",
       "engines": {
         "node": ">=10"
       }
@@ -1102,24 +1136,24 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.16.4.tgz",
-      "integrity": "sha512-Zbux4MepXzFfIkgViwVv1upqQuYt3P9ak8JQGHUQVIeNguj6GYTSf4q+6u1kx0Lw6cJl765bH529qIJifs8Cng==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.19.3.tgz",
+      "integrity": "sha512-m4+p8OXor+hufy8yd5ZcuJKFNb7zYAlNp77GQl6LV+6DcfFGxDGN+2R/5qwh1Fot9ufIiGRkRTl5aWYrd2PUVg==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.16.4.tgz",
-      "integrity": "sha512-0gD7ZEvsZlQUFiQX8gBVIyeekGxJgkNYKe2zYOpxzRUHgzqQsMZQl4gID2aTyQjdFMZegdHN0foY1KYTyJY01w==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.19.3.tgz",
+      "integrity": "sha512-DoekRfYh1ihJJ7Oeuju0kkpGnqas0xl5Yugu1JJ+snW/tRG8+0legigY0SHkjyPbJoFChvK1sKZE8xP12Cc7Fw==",
       "dependencies": {
         "@babel/traverse": "^7.19.0",
         "chalk": "^4.1.2",
         "esbuild": "^0.19.0",
         "esbuild-register": "^3.4.1",
-        "get-it": "^8.4.3",
+        "get-it": "^8.4.4",
         "golden-fleece": "^1.0.9",
         "pkg-dir": "^5.0.0"
       },
@@ -1127,7 +1161,7 @@
         "sanity": "bin/sanity"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@sanity/cli/node_modules/ansi-styles": {
@@ -1195,12 +1229,12 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.4.11.tgz",
-      "integrity": "sha512-A8s5odg9b8ioamKDdfrfsp5rHsE8J+BOpknw6eRtIHF5BBkNGAYdS78NdS1m3R+llHotdpyS/X2+la4YgzU5/w==",
+      "version": "6.22.4",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.22.4.tgz",
+      "integrity": "sha512-l807VLFs/CVrbWoqQ6C9SNqpvSvNkNnJ5RgxUSfCB2t8elkJ7fr3ahi1bbGrIMrfr/uL044WfWIQ4E3DoqpiuQ==",
       "dependencies": {
-        "@sanity/eventsource": "^5.0.0",
-        "get-it": "^8.4.3",
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.6.5",
         "rxjs": "^7.0.0"
       },
       "engines": {
@@ -1213,14 +1247,14 @@
       "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
     },
     "node_modules/@sanity/diff": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.16.4.tgz",
-      "integrity": "sha512-EPPY2wY8s2Gehxg0I3+mk+f76flMcF0hkWx4bXk5x4Lpjxrk2c4xDon5tzau6zs/vQD+5zUsyRvGIvwiUyttZA==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.19.3.tgz",
+      "integrity": "sha512-stzVGEBGUP4Gytkukad/zQJ8QOVXQjKwJzhbI5LnPcRgQI5bccAYYY9mJkPWkjIerolyo/4bc3qYB48RaQBVPg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@sanity/diff-match-patch": {
@@ -1232,24 +1266,24 @@
       }
     },
     "node_modules/@sanity/eventsource": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.0.tgz",
-      "integrity": "sha512-0ewT+BDzfiamHwitUfRcwsl/RREHjWv6VNZvQ8Q4OnnNKXfEEGXbWmqzof0okOTkp4XELgyliht4Qj28o9AU2g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
+      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
       "dependencies": {
-        "@types/event-source-polyfill": "1.0.1",
-        "@types/eventsource": "1.1.11",
+        "@types/event-source-polyfill": "1.0.5",
+        "@types/eventsource": "1.1.15",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.16.4.tgz",
-      "integrity": "sha512-Ufyn8l1J4MfNSkxsart0O5BSv+VIPWaollXkJSYBoevXbZpju2b9bVdo33aAXiXSdsWDLEit+bH1ie9Wr9rQog==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.19.3.tgz",
+      "integrity": "sha512-DrDfHJS7oybIynKNiRthiqg4zJT/CzfgyydQXfkVUPquxjO629VeDXLDfvhvNLrF1ZqNZTtdrF6ngggfXoDZzw==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
-        "get-it": "^8.4.3",
+        "get-it": "^8.4.4",
         "lodash": "^4.17.21",
         "mississippi": "^4.0.0",
         "p-queue": "^2.3.0",
@@ -1257,7 +1291,7 @@
         "split2": "^3.2.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@sanity/export/node_modules/debug": {
@@ -1293,17 +1327,17 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.16.4.tgz",
-      "integrity": "sha512-dShe+Sf5oJRSwjLjuiC+DGhrYYRRQgGGb/8Z8A4zekvKnt9WF89pAFWfIJ19f7VH5K1P4WLQwUJLCKQ+OyU5Eg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.19.3.tgz",
+      "integrity": "sha512-9uXanchWewUVtMMVCFGWI3vhULb48LZBa+pq6AMDnqLcWl4+SmjGthx7gmUf2re8A2Fy6bl0H74uqAEMzCpLCg==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.16.4",
+        "@sanity/mutator": "3.19.3",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
-        "get-it": "^8.4.3",
+        "get-it": "^8.4.4",
         "get-uri": "^2.0.2",
         "globby": "^10.0.0",
         "gunzip-maybe": "^1.4.1",
@@ -1317,7 +1351,7 @@
         "tar-fs": "^2.1.1"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@sanity/import/node_modules/debug": {
@@ -1341,9 +1375,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.16.4.tgz",
-      "integrity": "sha512-Z/mTY6hb9fuCWubH5X2HIbfpE3Cwv+E6Q1XZdRq908akSQBOyEOWBXbEL4SJytquz2nSWvDTFnfi/L6gqx3ypg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.19.3.tgz",
+      "integrity": "sha512-BdTz4m5Q757/A024DrNJMtFaeRQYApX6yMAU5GyQjBH/NEF94ZXglZ9AiEgqZ7U+b9R6cAouCH/k4dsbJn0Sbg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -1360,27 +1394,27 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.16.4.tgz",
-      "integrity": "sha512-yrPjJGLJ6yZ8wBD1yyVGjns6n4eI+U01rT5nRMy8MrVuo11K/r5USuP3fIOMzmUhGgDX6JRmxbL4jJ3cvUIKqg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.19.3.tgz",
+      "integrity": "sha512-9a92Uv8RaIqIx98ODR/wmGBFqkxxII0MEySKs0Xh4OW/c/7k0Uax6CiZswOZtJqErMqQyfCiH5gf/uRSJmcbZQ==",
       "dependencies": {
-        "@sanity/block-tools": "3.16.4",
-        "@sanity/schema": "3.16.4",
-        "@sanity/types": "3.16.4",
-        "@sanity/util": "3.16.4",
+        "@sanity/block-tools": "3.19.3",
+        "@sanity/schema": "3.19.3",
+        "@sanity/types": "3.19.3",
+        "@sanity/util": "3.19.3",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
-        "slate": "0.94.1",
-        "slate-react": "0.98.1"
+        "slate": "0.100.0",
+        "slate-react": "0.101.0"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": "^16.9 || ^17 || ^18",
         "rxjs": "^7",
-        "styled-components": "^5.2"
+        "styled-components": "^5.2 || ^6"
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/debug": {
@@ -1391,13 +1425,39 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@sanity/portable-text-editor/node_modules/slate-react": {
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.101.0.tgz",
+      "integrity": "sha512-GAwAi9cT8pWLt65p6Fab33UXH2MKE1NRzHhqAnV+32u20vy4dre/dIGyyqrFyOp3lgBBitgjyo6N2g26y63gOA==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@types/is-hotkey": "^0.1.8",
+        "@types/lodash": "^4.14.200",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/@sanity/portable-text-editor/node_modules/slate-react/node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
+    },
     "node_modules/@sanity/schema": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.16.4.tgz",
-      "integrity": "sha512-cOwtG0XeeQQDG2XfD3xvJWmgXbrJEhH/vTWPPBgR/WTVVkzbphX0q5lB/dg+sDYdevH/ULo5wXE0RQfLfJHgoQ==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.19.3.tgz",
+      "integrity": "sha512-KQfNuSRAPuRpft7H3X+L3rLtF8zjbIs/d/3jbrRZHqYPxhe1oTtqlf2X3En389Kym4DSSlQ625yZ/zmJYJDVIQ==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.16.4",
+        "@sanity/types": "3.19.3",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1406,24 +1466,24 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.16.4.tgz",
-      "integrity": "sha512-hucdBktsM9dPtKNQmAKeBF2pVa81YZ2oJ5+IQbRsnzEKRl5UJEGb6HQ9u/qHr/0Sg4WJzi+RrjltOO7HqZ+rHg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.19.3.tgz",
+      "integrity": "sha512-yiAwDqn058GD4rGl7hGVNH21rqR5hQlk0LBLB2BX4qnrxrqZ30+xFHwjgRM8EYFN51VspEbtov2jQmCijlIOpg==",
       "dependencies": {
-        "@sanity/client": "^6.4.9",
+        "@sanity/client": "^6.8.5",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.8.2.tgz",
-      "integrity": "sha512-XWtVdIG1PWBEiNPcObRfXsX/EPhiPCHMmfdn+frPIVLTLnoQnNju3W9UQAWec+BwjXBCpPtfc36AoiQSDUkxzw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.9.3.tgz",
+      "integrity": "sha512-AdWEVFaK0Snk6xxP0lGPVP3QQYKwzkfGFpFZnL9d6UtWt8yeuS8BMLVAzmXzg14hrqH50ex9nvNl3eq6a0MWiw==",
       "dependencies": {
         "@floating-ui/react-dom": "2.0.0",
         "@sanity/color": "^2.2.5",
         "@sanity/icons": "^2.4.1",
         "csstype": "^3.1.2",
-        "framer-motion": "^10.16.1",
+        "framer-motion": "^10.16.2",
         "react-refractor": "^2.1.7"
       },
       "engines": {
@@ -1437,16 +1497,16 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.16.4.tgz",
-      "integrity": "sha512-JrGhWBPFxeB4b7m1CrugSUcfSQ/PuvXfbx0lxj5BHbXlBC8y0cRUfDo/OWE31YLO6S6kNZXXiYx8/zP0JwOcrw==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.19.3.tgz",
+      "integrity": "sha512-70VE9Xy8DZS5hHatu54nhU/qv4orrelV7/C3M/EoXyhTTOcvUoWXTTKzasqBGSUNASxKkNX9GuGoj7tUtPWCVQ==",
       "dependencies": {
-        "@sanity/types": "3.16.4",
+        "@sanity/types": "3.19.3",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       }
     },
     "node_modules/@sanity/uuid": {
@@ -1459,9 +1519,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.16.4.tgz",
-      "integrity": "sha512-3iV9TyhIeZUoiWMckFYotJBAsFFn7tuHoQMz3nZP+YZRdY1C5hC5h8yFQp22KHSW6tivhOza0g9Z2pfhsfWQtw==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.19.3.tgz",
+      "integrity": "sha512-Bc3yhM8zMHakwxscNuz7PMG7+MvTreU6W97yX8+IuWBsdg4a6P5nOEgDvaPod6krCyGrr3f4MmwHWmLRqH9+Qw==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1474,8 +1534,8 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@rexxars/react-split-pane": "^0.1.93",
         "@sanity/color": "^2.1.20",
-        "@sanity/icons": "^2.4.0",
-        "@sanity/ui": "^1.7.2",
+        "@sanity/icons": "^2.6.0",
+        "@sanity/ui": "^1.9.3",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -1484,7 +1544,7 @@
       },
       "peerDependencies": {
         "react": "^18",
-        "styled-components": "^5.2"
+        "styled-components": "^5.2 || ^6"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -1520,14 +1580,22 @@
       }
     },
     "node_modules/@types/event-source-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.1.tgz",
-      "integrity": "sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw=="
     },
     "node_modules/@types/eventsource": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.11.tgz",
-      "integrity": "sha512-L7wLDZlWm5mROzv87W0ofIYeQP5K2UhoFnnUyEWLKM6UBb0ZNRgAqp98qE5DkgfBXdWfc2kYmw9KZm4NLjRbsw=="
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA=="
+    },
+    "node_modules/@types/follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-GWXfsD0Jc1RWiFmMuMFCpXMzi9L7oPDVwxUnZdg89kDNnqsRfUKXEtUYtA98A6lig1WXH/CYY/fvPW9HuN5fTA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -1539,22 +1607,22 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
-      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
       "dependencies": {
         "@types/unist": "^2"
       }
     },
     "node_modules/@types/is-hotkey": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.7.tgz",
-      "integrity": "sha512-yB5C7zcOM7idwYZZ1wKQ3pTfjA9BbvFqRWvKB46GFddxnJtHwi/b9y84ykQtxQPg5qhdpg4Q/kWU3EGoCTmLzQ=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.198",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.198.tgz",
-      "integrity": "sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg=="
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -1570,6 +1638,14 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+    },
+    "node_modules/@types/progress-stream": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/progress-stream/-/progress-stream-2.0.5.tgz",
+      "integrity": "sha512-5YNriuEZkHlFHHepLIaxzq3atGeav1qCTGzB74HKWpo66qjfostF+rHc785YYYHeBytve8ZG3ejg42jEIfXNiQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -1618,14 +1694,14 @@
       "integrity": "sha512-nBHZAaNTEw1YG3ROL7HtTp7HjW8HD7DuFYbWoonUKTZHj7eyOt4vPzyMcc3+xgWNv7xi2rziaiBXHIq6wBeyrw=="
     },
     "node_modules/@types/unist": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.8.tgz",
-      "integrity": "sha512-d0XxK3YTObnWVp6rZuev3c49+j4Lo8g4L1ZRm9z5L0xpoZycUPshHgczK5gsUMaZOstjVYYi09p5gYvUtfChYw=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.5.tgz",
+      "integrity": "sha512-+fHc7rdrgMIng29ISUqNjsbPl1EMo1PCDh/+16HNlTOJeQzs6c9Om23rVizETd3dDx4YM+aWGbyF/KP4FUwZyg=="
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -1841,9 +1917,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1935,11 +2011,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2221,9 +2297,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.0.tgz",
-      "integrity": "sha512-Yk1An4qzo5++Cu6peT9PsmRKIU8tALpmdoE09n//AfGQFcPfx21/tMGMsmKYmLJWaBJrGOJ5Jz5hoU+7cZZUWQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2587,14 +2663,14 @@
       }
     },
     "node_modules/duplexify": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
-      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.0"
+        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/duplexify/node_modules/readable-stream": {
@@ -2803,9 +2879,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2823,9 +2899,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2844,9 +2920,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2900,9 +2976,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -3041,18 +3117,15 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.4.6.tgz",
-      "integrity": "sha512-omefjdbyRb2rRt0tnrZlbeWx9oZJm66o88K8JlYn13xELn+0+d6mJZOQHrJAdC3vxeJ4t/NHa4wh7Wlh+nvEJA==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.6.5.tgz",
+      "integrity": "sha512-o1hjPwrb/icm3WJbCweTSq8mKuDfJlqwbFauI+Pdgid99at/BFaBXFBJZE+uqvHyOVARE4z680S44vrDm8SsCw==",
       "dependencies": {
-        "debug": "^4.3.4",
+        "@types/follow-redirects": "^1.14.4",
+        "@types/progress-stream": "^2.0.5",
         "decompress-response": "^7.0.0",
-        "follow-redirects": "^1.15.4",
-        "into-stream": "^6.0.0",
-        "is-plain-object": "^5.0.0",
+        "follow-redirects": "^1.15.6",
         "is-retry-allowed": "^2.2.0",
-        "is-stream": "^2.0.1",
-        "parse-headers": "^2.0.5",
         "progress-stream": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       },
@@ -3072,9 +3145,9 @@
       }
     },
     "node_modules/get-random-values-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-random-values-esm/-/get-random-values-esm-1.0.0.tgz",
-      "integrity": "sha512-BVgZ1PZwR5NKDpHpUcPmWcAQpoIOPXaFy6Vni3UdPbOlxO7eknhxsfytxwss16f75EABfnAC+XZjzTurNlPY/g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-random-values-esm/-/get-random-values-esm-1.0.2.tgz",
+      "integrity": "sha512-HMSDTgj1HPFAuZG0FqxzHbYt5JeEGDUeT9r1RLXhS6RZQS8rLRjokgjZ0Pd28CN0lhXlRwfH6eviZqZEJ2kIoA==",
       "dependencies": {
         "get-random-values": "^1.2.2"
       }
@@ -3123,6 +3196,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3352,17 +3426,17 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -3403,6 +3477,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3412,21 +3487,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
@@ -3894,11 +3954,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4002,9 +4062,9 @@
       "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
@@ -4093,9 +4153,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4174,14 +4237,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
       "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
       "engines": {
         "node": ">=8"
       }
@@ -4277,11 +4332,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -4775,11 +4825,10 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-refractor": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-2.1.7.tgz",
-      "integrity": "sha512-avNxSSsnjYg+BKpO8LVCK14KRn5pLZ+8DInMiUEeZPL6hs0SN0zafl3mJIxavGQPKyihqbXqzq4CYNflJQjaaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-2.2.0.tgz",
+      "integrity": "sha512-UvWkBVqH/2b9nkkkt4UNFtU3aY1orQfd4plPjx5rxbefy6vGajNHU9n+tv8CbykFyVirr3vEBfN2JTxyK0d36g==",
       "dependencies": {
-        "prop-types": "^15.8.1",
         "refractor": "^3.6.0",
         "unist-util-filter": "^2.0.2",
         "unist-util-visit-parents": "^3.0.2"
@@ -4976,6 +5025,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4987,9 +5037,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
-      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5061,37 +5111,38 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.16.4",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.16.4.tgz",
-      "integrity": "sha512-djfzmKsxwxbU6NKOFZbMyihcsg/eVEKXVqHqIf4K4Io5wNhXMZZ1cD9dpSz5sVEE8/u8vvK+7HUjqjQZ1Zl57g==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.19.3.tgz",
+      "integrity": "sha512-Lz8yynVaZZrtzGcPiWZlZ8wml8xBOnw9O4n/0Nq7dcSeg43kaGIHi0pUSFs3Ft0D7KkgT8fdGCoKN4HabDeZBA==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
         "@dnd-kit/sortable": "^7.0.1",
         "@dnd-kit/utilities": "^3.2.0",
         "@juggle/resize-observer": "^3.3.1",
+        "@portabletext/react": "^3.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.16.4",
-        "@sanity/cli": "3.16.4",
-        "@sanity/client": "^6.4.9",
+        "@sanity/block-tools": "3.19.3",
+        "@sanity/cli": "3.19.3",
+        "@sanity/client": "^6.8.5",
         "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.16.4",
+        "@sanity/diff": "3.19.3",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.16.4",
+        "@sanity/export": "3.19.3",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "^2.4.0",
+        "@sanity/icons": "^2.6.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.16.4",
+        "@sanity/import": "3.19.3",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.16.4",
-        "@sanity/portable-text-editor": "3.16.4",
-        "@sanity/schema": "3.16.4",
-        "@sanity/types": "3.16.4",
-        "@sanity/ui": "^1.7.2",
-        "@sanity/util": "3.16.4",
+        "@sanity/mutator": "3.19.3",
+        "@sanity/portable-text-editor": "3.19.3",
+        "@sanity/schema": "3.19.3",
+        "@sanity/types": "3.19.3",
+        "@sanity/ui": "^1.9.3",
+        "@sanity/util": "3.19.3",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
@@ -5099,7 +5150,7 @@
         "@types/react-is": "^18.2.0",
         "@types/shallow-equals": "^1.0.0",
         "@types/speakingurl": "^13.0.3",
-        "@types/use-sync-external-store": "^0.0.3",
+        "@types/use-sync-external-store": "^0.0.5",
         "@vitejs/plugin-react": "^4.0.0",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5116,7 +5167,7 @@
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
         "framer-motion": "^10.0.0",
-        "get-it": "^8.4.3",
+        "get-it": "^8.4.4",
         "get-random-values-esm": "^1.0.0",
         "groq-js": "^1.1.12",
         "hashlru": "^2.3.0",
@@ -5171,12 +5222,12 @@
         "sanity": "bin/sanity"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18",
-        "styled-components": "^5.2"
+        "styled-components": "^5.2 || ^6"
       }
     },
     "node_modules/sanity-diff-patch": {
@@ -5282,11 +5333,11 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.6.tgz",
-      "integrity": "sha512-x+CW0kOzlFNOnseF0DBr0AJ5m+TgGmSOdEZwyiZW0gV87XBvxQKw5A8DvFFgabznA68XqLgVX+PwPX8OzsFvRA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "dependencies": {
-        "compute-scroll-into-view": "^3.0.0"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/semver": {
@@ -5379,47 +5430,13 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.94.1",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.94.1.tgz",
-      "integrity": "sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==",
+      "version": "0.100.0",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.100.0.tgz",
+      "integrity": "sha512-cK+xwLBrbQof4rEfTzgC8loBWsDFEXq8nOBY7QahwY59Zq4bsBNcwiMw2VIzTv+WGNsmyHp4eAk/HJbz2aAUkQ==",
       "dependencies": {
-        "immer": "^9.0.6",
+        "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
-      }
-    },
-    "node_modules/slate-react": {
-      "version": "0.98.1",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.1.tgz",
-      "integrity": "sha512-ta4TAxoHE740e5EYSjAvK2bSpvrvnTkPfwMmx7rV+z/r8sng/RaJpc5cL9Rt2sfqQonSZOnQtAIaL6g97bLgzw==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.65.3"
-      }
-    },
-    "node_modules/slate-react/node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
-    },
-    "node_modules/slate-react/node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
-      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
-      "dependencies": {
-        "compute-scroll-into-view": "^1.0.20"
       }
     },
     "node_modules/source-map": {
@@ -5520,9 +5537,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5700,9 +5717,9 @@
       }
     },
     "node_modules/tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.16.4",
-    "@sanity/cli": "3.16.4",
-    "@sanity/vision": "3.16.4",
+    "sanity": "3.19.3",
+    "@sanity/cli": "3.19.3",
+    "@sanity/vision": "3.19.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.11.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.19.3",
-    "@sanity/cli": "3.19.3",
-    "@sanity/vision": "3.19.3",
+    "sanity": "3.20.0",
+    "@sanity/cli": "3.20.0",
+    "@sanity/vision": "3.20.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.11.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.20.0",
-    "@sanity/cli": "3.20.0",
-    "@sanity/vision": "3.20.0",
+    "sanity": "3.22.2",
+    "@sanity/cli": "3.22.2",
+    "@sanity/vision": "3.22.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.11.0",


### PR DESCRIPTION
Output frå npm i før/etter desse oppdateringane:

### Før
```bash
❯ npm i

added 35 packages, removed 35 packages, changed 102 packages, and audited 586 packages in 5s

68 packages are looking for funding
  run `npm fund` for details

6 vulnerabilities (3 moderate, 3 high)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
```

### Etter:
```bash
❯ npm i

added 35 packages, removed 35 packages, changed 102 packages, and audited 586 packages in 5s

68 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```