### PR TITLE
Oppdater Sanity frå v3.22 til v3.24.1

### DIFF
--- a/.sanity/runtime/index.html
+++ b/.sanity/runtime/index.html
@@ -3,7 +3,7 @@
 This file is auto-generated from "sanity dev".
 Modifications to this file are automatically discarded.
 -->
-<head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/><meta name="robots" content="noindex"/><meta name="referrer" content="same-origin"/><link rel="icon" href="/static/favicon.ico" sizes="any"/><link rel="icon" href="/static/favicon.svg" type="image/svg+xml"/><link rel="apple-touch-icon" href="/static/apple-touch-icon.png"/><link rel="manifest" href="/static/manifest.webmanifest"/><title>Sanity Studio</title><script>
+<head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"/><meta name="robots" content="noindex"/><meta name="referrer" content="same-origin"/><link rel="icon" href="/static/favicon.ico" sizes="any"/><link rel="icon" href="/static/favicon.svg" type="image/svg+xml"/><link rel="apple-touch-icon" href="/static/apple-touch-icon.png"/><link rel="manifest" href="/static/manifest.webmanifest"/><title>Sanity Studio</title><script>
 ;(function () {
   var _caughtErrors = []
 
@@ -170,6 +170,62 @@ Modifications to this file are automatically discarded.
   })
 })()
 </script><style>
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 400;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Regular.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 400;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Italic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 500;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Medium.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 500;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-MediumItalic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 600;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-SemiBold.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 600;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-SemiBoldItalic.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: normal;
+    font-weight: 700;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-Bold.woff2") format("woff2");
+  }
+  @font-face {
+    font-family: Inter;
+    font-style: italic;
+    font-weight: 700;
+    font-display: swap;
+    src: url("https://studio-static.sanity.io/Inter-BoldItalic.woff2") format("woff2");
+  }
   html {
     background-color: #f1f3f6;
   }

--- a/components/navLogo.tsx
+++ b/components/navLogo.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import navLogoPng from "/static/nav-logo.png";
-
-const NavLogo = () => (
-    <img src={navLogoPng} width="70px" alt="Nav-logo" style={{margin: "0 2rem 0 .75rem"}} />
-  );
-  
-export default NavLogo;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.23.4",
-        "@sanity/vision": "3.23.4",
+        "@sanity/cli": "3.24.1",
+        "@sanity/vision": "3.24.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-icons": "5.3.0",
-        "sanity": "3.23.4",
+        "sanity": "3.24.1",
         "short-uuid": "4.2.2",
         "styled-components": "5.3.11"
       }
@@ -849,26 +849,38 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.12",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -1067,18 +1079,18 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.23.4.tgz",
-      "integrity": "sha512-ep6VEcAQJVZvrEWTT92w7qmPmYhXqcvCXYqbaizaSEHPE41g4slZ2/qQTeSW07Qh57rVAK5lWqRogbH00Ml6Ig==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.24.1.tgz",
+      "integrity": "sha512-sz6QO1r5NiJa33waEHukxoaHz7w0LwsSYUzKVm60+AS8Gi9/Im0NwYsKqpORveuSZCujZzwm//PMjr3dCR0Czg==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.23.4.tgz",
-      "integrity": "sha512-wt6GROBl2M+OHVLbErs2ubFOy8Z1i3H3cmDoQPmKNIJfzPv2FG2cPviMmgfS9xDtjLiSfapcypAu8mYSJWGopg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.24.1.tgz",
+      "integrity": "sha512-Wmbz/keuY/8bZ74xZNO1koAYp91Kpj7rsszKszMkRArlCFtwOixQITlrj4ylnYl1UnJW7VsITqSFuaLsnT0Quw==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
         "@sanity/telemetry": "^0.7.5",
@@ -1181,9 +1193,9 @@
       "peer": true
     },
     "node_modules/@sanity/diff": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.23.4.tgz",
-      "integrity": "sha512-P4cuk3MG1NOrhTakdp1yH/SlRZKvsRtxXiQjFNHNeKU39ae9ky4zQLWg3bvAaTT7MHTBapnOsZIXfWmMaqId3Q==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.24.1.tgz",
+      "integrity": "sha512-fy/ygiQsgxqBiUP/ys6RtDhk3+XP/rmUyrKd3pU7t4v26HsJNDkFktpp+xoWUGmxvFsIBvMBv6aje1X5pPrHVQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -1211,9 +1223,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.23.4.tgz",
-      "integrity": "sha512-y3o6+zgC70hLIAzc1J5oQDwKut0jtafT/8hPMhHnVCYDFMDlT6LANUDxoK/eIgOSN1Xc/O2d6Ev7fODJMbWgEw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.24.1.tgz",
+      "integrity": "sha512-k+lJ+nwgGgQaYQdcUhcFLcHAov/qStPnQCSOImyIibzJpkmWPRYBNpEc556q8SPrGsOZIp71zgtEPp1YMYVVNw==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -1242,17 +1254,17 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/groq-store": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.3.7.tgz",
-      "integrity": "sha512-wrAr7PKfbdRvfiC5m7unjH4x5XGZV+vMkk/CwrdHRs+39kuWWJvkwhVNRTS6iWTrTMgpMIe/H1kRrkle0PieDQ==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.3.10.tgz",
+      "integrity": "sha512-svSSxRcAbJYvhrOxwlYkRgry34aHyCk9o8o1BflaUEKjN5VOJO9wyA8TvDEta+WpGy2oZFrz4jzszNx8rCeDhA==",
       "dependencies": {
-        "mnemonist": "0.39.6"
+        "mnemonist": "0.39.7"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.10.0"
+        "@sanity/client": "^6.11.0"
       }
     },
     "node_modules/@sanity/icons": {
@@ -1275,13 +1287,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.23.4.tgz",
-      "integrity": "sha512-r2GIWRNuH52X60cjHOjCf4pXi+ZqayY96CvMYK7Y74jR3oIewK58jDVDxMBEFuCSTZ1dCHY/cth/F9c/tHyiIw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.24.1.tgz",
+      "integrity": "sha512-OAc/Le7tpRMSqByjg89as2NZuatXTybm/KTEYBuBUn6K+2coh+JgQ6cnknpnPFslw1j7VGBKeGrbRUzXJsy7Ew==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.23.4",
+        "@sanity/mutator": "3.24.1",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -1323,9 +1335,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.23.4.tgz",
-      "integrity": "sha512-y5XFzzqxkokaykzwCzaaQPO2zeNSxtH2KAxgnhQDVFrgHgGbz3WIxEEImBlWiwy0ZRwKMsv9bFIbvKL/0fd9yQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.24.1.tgz",
+      "integrity": "sha512-CD8DZZpdK0hev4raAMgDtto7GAitdhMrctfwZlV8f3awEIqHZCXcbtIGuKXmDzoQ3fktWI0j8YwI78qixWvBtg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -1342,14 +1354,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.23.4.tgz",
-      "integrity": "sha512-mWJ3VFOtJIu7n4ptXeENZOcIT/UPkYlErymEGRKAOtYmswc6/lHvfx+QX/PN0E9zcIgGhcgT8/4OH9tkewY7IA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.24.1.tgz",
+      "integrity": "sha512-w5ntY4s9TRuULgdmcWj4pGSJ/EiWB0J2WGEAXbkQsZn5kQp1qpaJ97YfRM0cwVD3UsWbOzgSjzv8xjOQxreNEA==",
       "dependencies": {
-        "@sanity/block-tools": "3.23.4",
-        "@sanity/schema": "3.23.4",
-        "@sanity/types": "3.23.4",
-        "@sanity/util": "3.23.4",
+        "@sanity/block-tools": "3.24.1",
+        "@sanity/schema": "3.24.1",
+        "@sanity/types": "3.24.1",
+        "@sanity/util": "3.24.1",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -1388,12 +1400,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.23.4.tgz",
-      "integrity": "sha512-QjnMmsK78SeVRomOHOgJwUqqxF4XsURLId0nq+BBk5MMHBcm/3tQYhIlRkRowUkM0gJJvECzSPyqoj/e0xnXZw==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.24.1.tgz",
+      "integrity": "sha512-SmXlytJNivz6s3efXOPjdaU+dXzHZhGa44I/Un3oJzLVb7jYF2WoC3tnwDELo8S1/nCE0vk0iJnL5Gqn0vVk/g==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.23.4",
+        "@sanity/types": "3.24.1",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1418,18 +1430,18 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.23.4.tgz",
-      "integrity": "sha512-v3EN73ECxlwHAScOhQhSnnfpZf62LX8vN62V3m6tY7+Umnc9XwKUoTtKiMQUKJy4XuZgarot3kM4/6GfB9Y3Mg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.24.1.tgz",
+      "integrity": "sha512-hbih87IjAQqdFHqPhggfHtaV5rxtCITZVVxHeerClABVdiYcdy5Yu10CJbKCXD3HzSkYhEeO3Fd8ljtFBoNmjg==",
       "dependencies": {
         "@sanity/client": "^6.10.0",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "2.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.0.0-beta.13.tgz",
-      "integrity": "sha512-neMMdrcUtcfLnzmRRrqLgdVOHpBqmFeN8wM2tu9fVOEDexXyL/CHFrOYlGG+A7JL6BJbOQxaryeFvmFKskZ2cA==",
+      "version": "2.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.0.0-beta.16.tgz",
+      "integrity": "sha512-nu+N1ClKv5e3sraBvJnru3/F3Nzl7uI85En3kPWg611GfHlu6x0WGVE/6kB0FQXkwMsaqehduiz9xgE2lKZopg==",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.4",
         "@sanity/color": "3.0.0-beta.9",
@@ -1448,18 +1460,6 @@
         "styled-components": "^5.2 || ^6"
       }
     },
-    "node_modules/@sanity/ui/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@sanity/ui/node_modules/@sanity/color": {
       "version": "3.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.0-beta.9.tgz",
@@ -1469,11 +1469,11 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.23.4.tgz",
-      "integrity": "sha512-ehWW1GifZVJxacyBDaiORogvD7Nzp1/WjzWCtRZ/Gjlt1kXJl4B7ESwPsbOtwRLGBnVB1wHcl7HsCStxEd5aqg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.24.1.tgz",
+      "integrity": "sha512-4TnjysKBdNMzZgGLwYii4ZTnYmvXz3ClYmyqJhPBKVcafip/r1q51OrIophW420Dhe9dIROjgguZAUiHnfXNYw==",
       "dependencies": {
-        "@sanity/types": "3.23.4",
+        "@sanity/types": "3.24.1",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.23.4.tgz",
-      "integrity": "sha512-R4eDoJLrFCaFosivAY3cKDlHVv1XGadZ7lfLYi9EjSaPsnaTRiu+QGtJ+NoAtdghEzLdSYLPL0H1FSWDHmeaJQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.24.1.tgz",
+      "integrity": "sha512-Cs7YQTlpLMfGjdwtex2qV/yoxXBryWPth0SpMkZZJNBb9HxJc06oeFpIGZlRcluu/FW3hoRFiyWzgwnEqApROg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1507,7 +1507,7 @@
         "@rexxars/react-split-pane": "^0.1.93",
         "@sanity/color": "3.0.0-beta.9",
         "@sanity/icons": "^2.8.0",
-        "@sanity/ui": "2.0.0-beta.13",
+        "@sanity/ui": "2.0.0-beta.16",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -4000,9 +4000,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mnemonist": {
-      "version": "0.39.6",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
-      "integrity": "sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==",
+      "version": "0.39.7",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.7.tgz",
+      "integrity": "sha512-ix3FwHWZgdXUt0dHM8bCrI4r1KMeYx8bCunPCYmvKXq4tn6gbNsqrsb4q0kDbDqbpIOvEaW5Sn+dmDwGydfrwA==",
       "dependencies": {
         "obliterator": "^2.0.1"
       }
@@ -5077,9 +5077,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.23.4.tgz",
-      "integrity": "sha512-KUzyA4+1/bLiL24HQNBMYtOwzZOaKh/dGDZ/Y9FVPsUFr2iyr8Mer6T1e/UT/4Lw2iQB6myfF4IfnEaqdvuWJA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.24.1.tgz",
+      "integrity": "sha512-/7X+s/vxsvkikxEIvxFpmypmnzyhNXXoO8Xl1ltDrQp9REZuIUIgpvpnqls6Sq7HuBAEC4s4M/JQfxq5WQ2yhA==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -5090,27 +5090,27 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.23.4",
-        "@sanity/cli": "3.23.4",
+        "@sanity/block-tools": "3.24.1",
+        "@sanity/cli": "3.24.1",
         "@sanity/client": "^6.10.0",
         "@sanity/color": "3.0.0-beta.9",
-        "@sanity/diff": "3.23.4",
+        "@sanity/diff": "3.24.1",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.23.4",
+        "@sanity/export": "3.24.1",
         "@sanity/generate-help-url": "^3.0.0",
         "@sanity/icons": "^2.8.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.23.4",
+        "@sanity/import": "3.24.1",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.23.4",
-        "@sanity/portable-text-editor": "3.23.4",
-        "@sanity/presentation": "1.4.0",
-        "@sanity/schema": "3.23.4",
+        "@sanity/mutator": "3.24.1",
+        "@sanity/portable-text-editor": "3.24.1",
+        "@sanity/presentation": "1.5.0",
+        "@sanity/schema": "3.24.1",
         "@sanity/telemetry": "^0.7.5",
-        "@sanity/types": "3.23.4",
-        "@sanity/ui": "2.0.0-beta.13",
-        "@sanity/util": "3.23.4",
+        "@sanity/types": "3.24.1",
+        "@sanity/ui": "2.0.0-beta.16",
+        "@sanity/util": "3.24.1",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
@@ -5220,16 +5220,16 @@
       }
     },
     "node_modules/sanity/node_modules/@sanity/presentation": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.4.0.tgz",
-      "integrity": "sha512-BDT7I7kfWuwqnOl34p0ytyUFrA+0/WT1zm0daSe0g8X8nKi++7HCa2fEbbRy49EG4tkrvWz14/aEtmiOImvMDw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.5.0.tgz",
+      "integrity": "sha512-Q44ta+83/DNwIrJ3hnx66G1xj/qOrreNZ6ZSK7zkCI4AJcPrQjejCoClOJu8yv0b0UNvzNM9cE6X6q5EbHP5Zw==",
       "dependencies": {
-        "@sanity/groq-store": "5.3.7",
+        "@sanity/groq-store": "5.3.10",
         "@sanity/icons": "^2.8.0",
-        "@sanity/preview-url-secret": "^1.4.0",
-        "@sanity/ui": "2.0.0-beta.13",
+        "@sanity/preview-url-secret": "^1.5.0",
+        "@sanity/ui": "2.0.0-beta.16",
         "@types/lodash.isequal": "^4.5.8",
-        "framer-motion": "^10.16.16",
+        "framer-motion": "^10.17.12",
         "lodash.isequal": "^4.5.0",
         "mendoza": "3.0.3",
         "rxjs": "^7.8.1",
@@ -5239,10 +5239,10 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.10.0",
+        "@sanity/client": "^6.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sanity": "^3.23.0",
+        "sanity": "^3.23.4",
         "styled-components": "^5.2 || ^6.1.1"
       },
       "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.22.2",
-        "@sanity/vision": "3.22.2",
+        "@sanity/cli": "3.23.4",
+        "@sanity/vision": "3.23.4",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-icons": "5.3.0",
-        "sanity": "3.22.2",
+        "sanity": "3.23.4",
         "short-uuid": "4.2.2",
         "styled-components": "5.3.11"
       }
@@ -865,18 +865,6 @@
         "@floating-ui/utils": "^0.2.8"
       }
     },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.0.tgz",
-      "integrity": "sha512-Ke0oU3SeuABC2C4OFu2mSAwHIP5WUiV98O9YWoHV4Q5aT6E9k06DV0Khi5uYspR8xmmBk08t8ZDcz3TR3ARkEg==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.2.7"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
@@ -1079,21 +1067,21 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.22.2.tgz",
-      "integrity": "sha512-9X3euFnXmzlsKrQmn7mxyMEvjZ31a1Yosws8nJuSL2hZtOEXmTibgMBu3FZs2nJQ2v+UJM/jhXZHOjd97h/wBA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.23.4.tgz",
+      "integrity": "sha512-ep6VEcAQJVZvrEWTT92w7qmPmYhXqcvCXYqbaizaSEHPE41g4slZ2/qQTeSW07Qh57rVAK5lWqRogbH00Ml6Ig==",
       "dependencies": {
         "get-random-values-esm": "^1.0.0",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.22.2.tgz",
-      "integrity": "sha512-QgvCQVIiES4CM1xH39eNHnbgKXaoeXk2Cb/4g/hlyrxWDK3zHgbgSwAhnQegRSqeC4Ifj1XeFEylLxk6P9EOfw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.23.4.tgz",
+      "integrity": "sha512-wt6GROBl2M+OHVLbErs2ubFOy8Z1i3H3cmDoQPmKNIJfzPv2FG2cPviMmgfS9xDtjLiSfapcypAu8mYSJWGopg==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/telemetry": "^0.7.3",
+        "@sanity/telemetry": "^0.7.5",
         "chalk": "^4.1.2",
         "esbuild": "^0.19.8",
         "esbuild-register": "^3.4.1",
@@ -1174,9 +1162,9 @@
       }
     },
     "node_modules/@sanity/client": {
-      "version": "6.22.4",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.22.4.tgz",
-      "integrity": "sha512-l807VLFs/CVrbWoqQ6C9SNqpvSvNkNnJ5RgxUSfCB2t8elkJ7fr3ahi1bbGrIMrfr/uL044WfWIQ4E3DoqpiuQ==",
+      "version": "6.24.3",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.24.3.tgz",
+      "integrity": "sha512-WfF6Gq2rCxv7n9IcWYRvtGpCYq4398MT303HJhwP/jf3jeU81OxWZ+ApGat37BOJ37tDZmhHxG3Pb1boDxA0EQ==",
       "dependencies": {
         "@sanity/eventsource": "^5.0.2",
         "get-it": "^8.6.5",
@@ -1189,12 +1177,13 @@
     "node_modules/@sanity/color": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.2.5.tgz",
-      "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw=="
+      "integrity": "sha512-tTi22KoKuER3sldXYl4c1Dq2zU7tMLDkljFiaUKVkBbu4PBvRGCFw75kXZnD2b4Bsp6vin+7sI+AKdCKRhfRuw==",
+      "peer": true
     },
     "node_modules/@sanity/diff": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.22.2.tgz",
-      "integrity": "sha512-n9tbvW64niQSvegYPdBzMFAOtvHvN9n4Ufiqn1pnFMqivb5LnC/YJbJoO6nAmTp+pdH1N5gQxZbSowQZEqVdQg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.23.4.tgz",
+      "integrity": "sha512-P4cuk3MG1NOrhTakdp1yH/SlRZKvsRtxXiQjFNHNeKU39ae9ky4zQLWg3bvAaTT7MHTBapnOsZIXfWmMaqId3Q==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -1222,9 +1211,9 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.22.2.tgz",
-      "integrity": "sha512-Wx2lKRhrKgw6ggH39+Zr73dRmlPBEUDAvE4pxyH9/LJGcCODyE0zRTsywswCYnAd7w67Zf3tqpkL1Ch/vGR/pA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.23.4.tgz",
+      "integrity": "sha512-y3o6+zgC70hLIAzc1J5oQDwKut0jtafT/8hPMhHnVCYDFMDlT6LANUDxoK/eIgOSN1Xc/O2d6Ev7fODJMbWgEw==",
       "dependencies": {
         "archiver": "^5.0.0",
         "debug": "^3.2.7",
@@ -1253,9 +1242,9 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/groq-store": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.3.5.tgz",
-      "integrity": "sha512-djrCQvrWwK2By+/zoqPR+oR2vRT94OUptCR8zHTVjpKkSrBd3/fJAyFfB0CBj90tdz4PSGcYFnRFIslsEJLTPA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-5.3.7.tgz",
+      "integrity": "sha512-wrAr7PKfbdRvfiC5m7unjH4x5XGZV+vMkk/CwrdHRs+39kuWWJvkwhVNRTS6iWTrTMgpMIe/H1kRrkle0PieDQ==",
       "dependencies": {
         "mnemonist": "0.39.6"
       },
@@ -1286,13 +1275,13 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.22.2.tgz",
-      "integrity": "sha512-zT3zLgSaTR7GI0mF36aRUZJrB3RIOhGCoth5v278icCTkVHvr8A3/KZjOCXu4EOS23eBmLS1oGrlFtc7VpfqRg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.23.4.tgz",
+      "integrity": "sha512-r2GIWRNuH52X60cjHOjCf4pXi+ZqayY96CvMYK7Y74jR3oIewK58jDVDxMBEFuCSTZ1dCHY/cth/F9c/tHyiIw==",
       "dependencies": {
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.22.2",
+        "@sanity/mutator": "3.23.4",
         "@sanity/uuid": "^3.0.1",
         "debug": "^3.2.7",
         "file-url": "^2.0.2",
@@ -1334,9 +1323,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.22.2.tgz",
-      "integrity": "sha512-U1GFZ5vmcU08gsqkuwqLAufQHR3wU8DGEfjo6BGHvuKXi3RMt3nHLDRn/EL0RWL/z0Bdz+zExoruXIYAU2EjRQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.23.4.tgz",
+      "integrity": "sha512-y5XFzzqxkokaykzwCzaaQPO2zeNSxtH2KAxgnhQDVFrgHgGbz3WIxEEImBlWiwy0ZRwKMsv9bFIbvKL/0fd9yQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -1353,14 +1342,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.22.2.tgz",
-      "integrity": "sha512-DQwCMcAUoFXQ3aYYcdghmHKht58H1aO/5SeCuqBNf8+wpq+B4gl4UiX08mcxHUSyxwMWfpGCuLhn81Z4pAIdwg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.23.4.tgz",
+      "integrity": "sha512-mWJ3VFOtJIu7n4ptXeENZOcIT/UPkYlErymEGRKAOtYmswc6/lHvfx+QX/PN0E9zcIgGhcgT8/4OH9tkewY7IA==",
       "dependencies": {
-        "@sanity/block-tools": "3.22.2",
-        "@sanity/schema": "3.22.2",
-        "@sanity/types": "3.22.2",
-        "@sanity/util": "3.22.2",
+        "@sanity/block-tools": "3.23.4",
+        "@sanity/schema": "3.23.4",
+        "@sanity/types": "3.23.4",
+        "@sanity/util": "3.23.4",
         "debug": "^3.2.7",
         "is-hotkey": "^0.1.6",
         "lodash": "^4.17.21",
@@ -1384,32 +1373,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/@sanity/portable-text-editor/node_modules/slate-react": {
-      "version": "0.101.0",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.101.0.tgz",
-      "integrity": "sha512-GAwAi9cT8pWLt65p6Fab33UXH2MKE1NRzHhqAnV+32u20vy4dre/dIGyyqrFyOp3lgBBitgjyo6N2g26y63gOA==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.8",
-        "@types/lodash": "^4.14.200",
-        "direction": "^1.0.4",
-        "is-hotkey": "^0.2.0",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.21",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "tiny-invariant": "1.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=18.2.0",
-        "react-dom": ">=18.2.0",
-        "slate": ">=0.99.0"
-      }
-    },
-    "node_modules/@sanity/portable-text-editor/node_modules/slate-react/node_modules/is-hotkey": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
-      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
-    },
     "node_modules/@sanity/preview-url-secret": {
       "version": "1.6.21",
       "resolved": "https://registry.npmjs.org/@sanity/preview-url-secret/-/preview-url-secret-1.6.21.tgz",
@@ -1425,12 +1388,12 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.22.2.tgz",
-      "integrity": "sha512-/+cP98tiflrdZlzIcJinNCfpO2oMF3UH1pg32aKK0VfSyuaJGaVk6Afqcp9ZVAemxadV54lyx9A/WbgBM7aRxA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.23.4.tgz",
+      "integrity": "sha512-QjnMmsK78SeVRomOHOgJwUqqxF4XsURLId0nq+BBk5MMHBcm/3tQYhIlRkRowUkM0gJJvECzSPyqoj/e0xnXZw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.22.2",
+        "@sanity/types": "3.23.4",
         "arrify": "^1.0.1",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
@@ -1455,24 +1418,24 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.22.2.tgz",
-      "integrity": "sha512-AdT0EGraxCx1ljb0kOo9l1yNyhnIPTES2/I8YbU3jJk+ghUayGl2jzbZyDbvhYMCf7VL0oH73/zBm8eeERIDAQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.23.4.tgz",
+      "integrity": "sha512-v3EN73ECxlwHAScOhQhSnnfpZf62LX8vN62V3m6tY7+Umnc9XwKUoTtKiMQUKJy4XuZgarot3kM4/6GfB9Y3Mg==",
       "dependencies": {
         "@sanity/client": "^6.10.0",
         "@types/react": "^18.0.25"
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-1.9.3.tgz",
-      "integrity": "sha512-AdWEVFaK0Snk6xxP0lGPVP3QQYKwzkfGFpFZnL9d6UtWt8yeuS8BMLVAzmXzg14hrqH50ex9nvNl3eq6a0MWiw==",
+      "version": "2.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-2.0.0-beta.13.tgz",
+      "integrity": "sha512-neMMdrcUtcfLnzmRRrqLgdVOHpBqmFeN8wM2tu9fVOEDexXyL/CHFrOYlGG+A7JL6BJbOQxaryeFvmFKskZ2cA==",
       "dependencies": {
-        "@floating-ui/react-dom": "2.0.0",
-        "@sanity/color": "^2.2.5",
-        "@sanity/icons": "^2.4.1",
+        "@floating-ui/react-dom": "^2.0.4",
+        "@sanity/color": "3.0.0-beta.9",
+        "@sanity/icons": "^2.7.0",
         "csstype": "^3.1.2",
-        "framer-motion": "^10.16.2",
+        "framer-motion": "^10.16.5",
         "react-refractor": "^2.1.7"
       },
       "engines": {
@@ -1485,12 +1448,32 @@
         "styled-components": "^5.2 || ^6"
       }
     },
-    "node_modules/@sanity/util": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.22.2.tgz",
-      "integrity": "sha512-yUyWhJmH1uBVdvjukqabd0lEpu6p71SehdJWoxaa3/UY9FGVibEhduU0/dTfwydCi/2mpXFX+9y93KfqHxuqrw==",
+    "node_modules/@sanity/ui/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
       "dependencies": {
-        "@sanity/types": "3.22.2",
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@sanity/ui/node_modules/@sanity/color": {
+      "version": "3.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.0-beta.9.tgz",
+      "integrity": "sha512-Mk7FRDtxz/U2SRlRM0BvUI62jU26W62aYsipaKFt/dk0rOyYa9yzfaojSM/QmW0E4W/nOw74RBA/HrapXUw+2Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sanity/util": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.23.4.tgz",
+      "integrity": "sha512-ehWW1GifZVJxacyBDaiORogvD7Nzp1/WjzWCtRZ/Gjlt1kXJl4B7ESwPsbOtwRLGBnVB1wHcl7HsCStxEd5aqg==",
+      "dependencies": {
+        "@sanity/types": "3.23.4",
         "get-random-values-esm": "^1.0.0",
         "moment": "^2.29.4"
       },
@@ -1508,9 +1491,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.22.2.tgz",
-      "integrity": "sha512-3ELf+bvG8V+209SgJZ+1rUjfVasOCUrivmW6NzZOMBYyuXrTatVZCRvb4+r+Q3eJ5ru2iLxlCi/OJhm4AZVeVQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.23.4.tgz",
+      "integrity": "sha512-R4eDoJLrFCaFosivAY3cKDlHVv1XGadZ7lfLYi9EjSaPsnaTRiu+QGtJ+NoAtdghEzLdSYLPL0H1FSWDHmeaJQ==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -1522,9 +1505,9 @@
         "@lezer/highlight": "^1.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
         "@rexxars/react-split-pane": "^0.1.93",
-        "@sanity/color": "^2.1.20",
-        "@sanity/icons": "^2.6.0",
-        "@sanity/ui": "^1.9.3",
+        "@sanity/color": "3.0.0-beta.9",
+        "@sanity/icons": "^2.8.0",
+        "@sanity/ui": "2.0.0-beta.13",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
         "is-hotkey": "^0.1.6",
@@ -1534,6 +1517,14 @@
       "peerDependencies": {
         "react": "^18",
         "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/@sanity/vision/node_modules/@sanity/color": {
+      "version": "3.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.0-beta.9.tgz",
+      "integrity": "sha512-Mk7FRDtxz/U2SRlRM0BvUI62jU26W62aYsipaKFt/dk0rOyYa9yzfaojSM/QmW0E4W/nOw74RBA/HrapXUw+2Q==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -1638,9 +1629,9 @@
       "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A=="
     },
     "node_modules/@types/lodash.isequal": {
       "version": "4.5.8",
@@ -2299,9 +2290,9 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
-      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2822,24 +2813,24 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
       }
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -4124,9 +4115,9 @@
       }
     },
     "node_modules/obliterator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
-      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="
     },
     "node_modules/observable-callback": {
       "version": "1.0.2",
@@ -5086,9 +5077,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.22.2.tgz",
-      "integrity": "sha512-1IY7pw2rYxch4pod/4tyLQMpF8W49XgdaDnvcrifaNtA2AbtbR3YvxAvxXzsrCgVvZ1HeYfYSVPRj15PUZOuzQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.23.4.tgz",
+      "integrity": "sha512-KUzyA4+1/bLiL24HQNBMYtOwzZOaKh/dGDZ/Y9FVPsUFr2iyr8Mer6T1e/UT/4Lw2iQB6myfF4IfnEaqdvuWJA==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -5099,27 +5090,27 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.22.2",
-        "@sanity/cli": "3.22.2",
+        "@sanity/block-tools": "3.23.4",
+        "@sanity/cli": "3.23.4",
         "@sanity/client": "^6.10.0",
-        "@sanity/color": "^2.1.20",
-        "@sanity/diff": "3.22.2",
+        "@sanity/color": "3.0.0-beta.9",
+        "@sanity/diff": "3.23.4",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.22.2",
+        "@sanity/export": "3.23.4",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/icons": "^2.6.0",
+        "@sanity/icons": "^2.8.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.22.2",
+        "@sanity/import": "3.23.4",
         "@sanity/logos": "^2.0.2",
-        "@sanity/mutator": "3.22.2",
-        "@sanity/portable-text-editor": "3.22.2",
-        "@sanity/presentation": "1.2.1",
-        "@sanity/schema": "3.22.2",
-        "@sanity/telemetry": "^0.7.3",
-        "@sanity/types": "3.22.2",
-        "@sanity/ui": "^1.9.3",
-        "@sanity/util": "3.22.2",
+        "@sanity/mutator": "3.23.4",
+        "@sanity/portable-text-editor": "3.23.4",
+        "@sanity/presentation": "1.4.0",
+        "@sanity/schema": "3.23.4",
+        "@sanity/telemetry": "^0.7.5",
+        "@sanity/types": "3.23.4",
+        "@sanity/ui": "2.0.0-beta.13",
+        "@sanity/util": "3.23.4",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/is-hotkey": "^0.1.7",
@@ -5220,15 +5211,23 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/sanity/node_modules/@sanity/color": {
+      "version": "3.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-3.0.0-beta.9.tgz",
+      "integrity": "sha512-Mk7FRDtxz/U2SRlRM0BvUI62jU26W62aYsipaKFt/dk0rOyYa9yzfaojSM/QmW0E4W/nOw74RBA/HrapXUw+2Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/sanity/node_modules/@sanity/presentation": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.2.1.tgz",
-      "integrity": "sha512-Bfb9rLcJu9DLBn1JDWZwkPfS8ItlJZoWPSdXnzQKPE4/RpNUX26xPhCkjxSH3Thg/ALMLNv3qZVHTPbFqqv1Tg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.4.0.tgz",
+      "integrity": "sha512-BDT7I7kfWuwqnOl34p0ytyUFrA+0/WT1zm0daSe0g8X8nKi++7HCa2fEbbRy49EG4tkrvWz14/aEtmiOImvMDw==",
       "dependencies": {
-        "@sanity/groq-store": "5.3.5",
+        "@sanity/groq-store": "5.3.7",
         "@sanity/icons": "^2.8.0",
-        "@sanity/preview-url-secret": "^1.3.5",
-        "@sanity/ui": "^1.9.3",
+        "@sanity/preview-url-secret": "^1.4.0",
+        "@sanity/ui": "2.0.0-beta.13",
         "@types/lodash.isequal": "^4.5.8",
         "framer-motion": "^10.16.16",
         "lodash.isequal": "^4.5.0",
@@ -5243,7 +5242,7 @@
         "@sanity/client": "^6.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "sanity": "^3.21.3",
+        "sanity": "^3.23.0",
         "styled-components": "^5.2 || ^6.1.1"
       },
       "peerDependenciesMeta": {
@@ -5466,6 +5465,32 @@
         "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
       }
+    },
+    "node_modules/slate-react": {
+      "version": "0.101.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.101.0.tgz",
+      "integrity": "sha512-GAwAi9cT8pWLt65p6Fab33UXH2MKE1NRzHhqAnV+32u20vy4dre/dIGyyqrFyOp3lgBBitgjyo6N2g26y63gOA==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@types/is-hotkey": "^0.1.8",
+        "@types/lodash": "^4.14.200",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/slate-react/node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -5696,9 +5721,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.23.4",
-    "@sanity/cli": "3.23.4",
-    "@sanity/vision": "3.23.4",
+    "sanity": "3.24.1",
+    "@sanity/cli": "3.24.1",
+    "@sanity/vision": "3.24.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.22.2",
-    "@sanity/cli": "3.22.2",
-    "@sanity/vision": "3.22.2",
+    "sanity": "3.23.4",
+    "@sanity/cli": "3.23.4",
+    "@sanity/vision": "3.23.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "5.3.0",

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -1,22 +1,9 @@
-import {buildLegacyTheme, createAuthStore, defineConfig} from 'sanity'
+import {createAuthStore, defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import {visionTool} from '@sanity/vision'
 import {schemas} from './schemas/schema'
 import {structure} from "./deskStructures/deskStructure";
 import NavLogo from "./components/navLogo"
-
-const NavTheme = buildLegacyTheme({
-    /* Brand colors */
-    '--brand-primary': '#0067c5',
-    '--brand-primary--inverted': '#ffffff',
-    '--brand-secondary': '#cce1ff',
-    '--brand-secondary--inverted': '#002252',
-    /* Typography */
-    '--font-size-base': '1.5rem',
-    /* Main Navigation */
-    '--main-navigation-color': '#595959',
-    '--main-navigation-color--inverted': '#ffffff'
-})
 
 export default defineConfig({
     name: "endringslogg",
@@ -49,5 +36,4 @@ export default defineConfig({
             logo: NavLogo,
         }
     },
-    theme: NavTheme
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -1,13 +1,12 @@
 import {createAuthStore, defineConfig} from 'sanity'
-import {deskTool} from 'sanity/desk'
+import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemas} from './schemas/schema'
 import {structure} from "./deskStructures/deskStructure";
-import NavLogo from "./components/navLogo"
 
 export default defineConfig({
     name: "endringslogg",
-    title: "endringslogg",
+    title: "Endringslogg",
     projectId: "li581mqu",
     dataset: "production",
     auth: createAuthStore({
@@ -25,15 +24,10 @@ export default defineConfig({
         ],
     }),
     plugins: [
-        deskTool({structure: structure}),
+        structureTool({structure: structure}),
         visionTool(),
     ],
     schema: {
         types: schemas
-    },
-    studio: {
-        components: {
-            logo: NavLogo,
-        }
     },
 })


### PR DESCRIPTION
Oppdaterer Sanity med nokre versjonar, neste steg vert å oppdatere styled-components til v6 i håp om at det skal fikse bygg-problemet eg møter på ved versjon 3.25.0.

Denne oppdateringa endrer utsjånaden på sida fordi logo og theme ikkje fungerer i nye versjonar. Snakka med Kari, og vi tykkjer ikkje det er verdt det å prøve å fikse desse tinga. 
Legg med før/etter-bilete.

Før: 

<img width="440" alt="Screenshot 2025-01-13 at 10 52 58" src="https://github.com/user-attachments/assets/b8dff0e9-68ca-4bd1-a264-de327970fe06" />

Etter:

<img width="440" alt="Screenshot 2025-01-13 at 12 37 10" src="https://github.com/user-attachments/assets/4aab16f6-9aa8-4007-afb6-a43caffbada5" />
