### PR TITLE
Oppdater sanity frå v3.36.4 til v3.48.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.36.4",
-        "@sanity/vision": "3.36.4",
+        "@sanity/cli": "3.39.0",
+        "@sanity/vision": "3.39.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-icons": "5.3.0",
-        "sanity": "3.36.4",
+        "sanity": "3.39.0",
         "short-uuid": "4.2.2",
         "styled-components": "^6.1.14"
       }
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.5.tgz",
-      "integrity": "sha512-OHqczNm4NTQlW1ghrVY43FPoiRzbmzNVbcgVnMKZN/RQYezHUSdjACjaX50CD3B7UIAjv39+MlsrVDb3v741FA==",
+      "version": "7.26.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+      "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -2301,6 +2301,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -2507,33 +2518,36 @@
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.36.4.tgz",
-      "integrity": "sha512-C56C28Ok2dxW9JzDG/goUt0+OqV28iVca0xkkW2cqh0ofmzBGohNWWVWeQqoNb1Xz4KeNfGHM4ljgnlplllAMg==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.39.0.tgz",
+      "integrity": "sha512-tDjpqyqLkOGgY9UWd9fWFht9F8DQ+bZqppyHoP2LkSusVdMsMjVx4tCNZJSIvnyUiqEHWHlQ8muALNduCSAQDg==",
+      "deprecated": "Renamed - use `@portabletext/block-tools` instead. `@sanity/block-tools` will no longer receive updates.",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.36.4.tgz",
-      "integrity": "sha512-RFxrDECVh3LuCvaTknMR1zE3JSSPNO0Bieg69SQpe88+OJykKsMY6JyX0TCZTZ4mefQwLGMfiTZVhxyD/D38kw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.39.0.tgz",
+      "integrity": "sha512-YJSRcdniZnBFzNssVw1qNYLo4/IqXPSYYWDHkA0928nh2aPf3HjK599sSWfyJmmW2lIERWz8WPJcZ7OWxNgpgA==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/codegen": "3.36.4",
+        "@sanity/client": "^6.15.20",
+        "@sanity/codegen": "3.39.0",
         "@sanity/telemetry": "^0.7.6",
-        "@sanity/util": "3.36.4",
+        "@sanity/util": "3.39.0",
         "chalk": "^4.1.2",
+        "debug": "^4.3.4",
         "decompress": "^4.2.0",
         "esbuild": "^0.20.0",
         "esbuild-register": "^3.4.1",
-        "get-it": "^8.4.16",
-        "golden-fleece": "^1.0.9",
+        "get-it": "^8.4.27",
         "groq-js": "^1.7.0",
         "node-machine-id": "^1.1.12",
         "pkg-dir": "^5.0.0",
         "semver": "^7.3.5",
+        "silver-fleece": "1.1.0",
         "validate-npm-package-name": "^3.0.0"
       },
       "bin": {
@@ -2621,9 +2635,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.36.4.tgz",
-      "integrity": "sha512-D7JEb/93RjYlY70CAtAIhYPG+6KWc2yBYRqW3RiNZi3c6FcC9C5YweT04QlmoaQeskjxj6JjB2SOp/AgHjEeYg==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.39.0.tgz",
+      "integrity": "sha512-ab42ElTO5Bu8TeU/IPYlwe9bRXsV05LMDPPqBDN+70egGJ1LB3s/FNwhC2e0LM+t89Qha8VFAFOUadmaru+ddA==",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/generator": "^7.23.6",
@@ -2635,6 +2649,7 @@
         "@babel/types": "^7.23.9",
         "debug": "^4.3.4",
         "globby": "^10.0.0",
+        "groq": "3.39.0",
         "groq-js": "^1.7.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
@@ -2653,9 +2668,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.36.4.tgz",
-      "integrity": "sha512-aehXqDIZ//GHDvV5xopMjmdTT3VXuspwVWt2hZqQ8vN8i9MICDM1izN4gw4oS4f7tHiKjkT9IDhIOzScFWRBCw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.39.0.tgz",
+      "integrity": "sha512-Z098rcSq3W3VgXABSmnI8+kop4KifK66MDbp1Kl8sY9VBa7kU3lTEts9Fnr+vNI1AoaD7XSBAlW6FcplQMBCjQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -2683,22 +2698,114 @@
       }
     },
     "node_modules/@sanity/export": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.36.4.tgz",
-      "integrity": "sha512-MXV69R7/ncL6dPtgXT9JG/IwZWb5BiMREcBxqdU968d14Oizn1IX+w/Nsjy4YKXgibeSCFnvqEzsvarmc5ax1A==",
+      "version": "3.42.2",
+      "resolved": "https://registry.npmjs.org/@sanity/export/-/export-3.42.2.tgz",
+      "integrity": "sha512-3dpGwzyhMXFPdGkS28rv7nBAnCKgW+OGTVM+tO31YO9AIZJ9M016WZcYKEYhX+wCLNiGTNrqWXfac9L4Unh8fQ==",
       "dependencies": {
-        "@sanity/util": "3.36.4",
+        "@sanity/client": "^6.24.1",
+        "@sanity/util": "3.68.3",
         "archiver": "^7.0.0",
         "debug": "^4.3.4",
-        "get-it": "^8.4.16",
+        "get-it": "^8.6.2",
+        "json-stream-stringify": "^2.0.2",
         "lodash": "^4.17.21",
         "mississippi": "^4.0.0",
         "p-queue": "^2.3.0",
-        "rimraf": "^3.0.2",
-        "split2": "^4.2.0"
+        "rimraf": "^6.0.1",
+        "split2": "^4.2.0",
+        "tar": "^7.0.1",
+        "yaml": "^2.4.2"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/@sanity/types": {
+      "version": "3.68.3",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.68.3.tgz",
+      "integrity": "sha512-JemibQXC08rHIXgjUH/p2TCiiD9wq6+dDkCvVHOooCvaYZNhAe2S9FAEkaA6qwWtPzyY2r6/tj1eDgNeLgXN1Q==",
+      "dependencies": {
+        "@sanity/client": "^6.24.1"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/@sanity/util": {
+      "version": "3.68.3",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.68.3.tgz",
+      "integrity": "sha512-J4Ov75oUvMqx221VEJkKNSibzF0D8VyCzejtwftW+jP80XguYFqBz7bAcTmwJ5vnxNUoAUCeAdZBoOYVpgew4g==",
+      "dependencies": {
+        "@sanity/client": "^6.24.1",
+        "@sanity/types": "3.68.3",
+        "get-random-values-esm": "1.0.2",
+        "moment": "^2.30.1",
+        "rxjs": "^7.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/export/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sanity/generate-help-url": {
@@ -2726,31 +2833,112 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.36.4.tgz",
-      "integrity": "sha512-ZpDyPXMeR1IFujLmlGAp8oBCKVEfbCIXQeIfjwRn/FitgTxq1FseUSfLmQfM9b4nvcVXcph7PufEXPc4WYi+pA==",
+      "version": "3.37.9",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-3.37.9.tgz",
+      "integrity": "sha512-9XdQ6C0iMp8zGmm3uyRnMnvURKRGY/tvEItjxC3vDa9MOkDSZoH6FrTWprTEETMsJdg2JUexG6fbUXW+Vorwhg==",
       "dependencies": {
-        "@sanity/asset-utils": "^1.2.5",
+        "@sanity/asset-utils": "^2.0.6",
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/mutator": "3.36.4",
-        "@sanity/uuid": "^3.0.1",
+        "@sanity/mutator": "^3.59.1",
+        "@sanity/uuid": "^3.0.2",
         "debug": "^4.3.4",
         "file-url": "^2.0.2",
-        "get-it": "^8.4.16",
+        "get-it": "^8.4.21",
         "get-uri": "^2.0.2",
-        "globby": "^10.0.0",
         "gunzip-maybe": "^1.4.1",
         "is-tar": "^1.0.0",
         "lodash": "^4.17.21",
+        "meow": "^9.0.0",
         "mississippi": "^4.0.0",
+        "ora": "^5.4.1",
         "p-map": "^1.2.0",
         "peek-stream": "^1.1.2",
-        "rimraf": "^3.0.2",
+        "pretty-ms": "^7.0.1",
+        "rimraf": "^6.0.1",
         "split2": "^4.2.0",
-        "tar-fs": "^2.1.1"
+        "tar-fs": "^2.1.1",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "sanity-import": "src/cli.js"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/@sanity/asset-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/asset-utils/-/asset-utils-2.2.1.tgz",
+      "integrity": "sha512-dBsZWH5X6ANcvclFRnQT9Y+NNvoWTJZIMKR5HT6hzoRpRb48p7+vWn+wi1V1wPvqgZg2ScsOQQcGXWXskbPbQQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/@sanity/mutator": {
+      "version": "3.70.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.70.0.tgz",
+      "integrity": "sha512-4Cc+9zFJsD3ywJRcnxr4SxURtM88zYaWJXHufGVDzDCnMMa/wd0VSHtuOEfuW09NirExiw1YsbFhHOTeuIl8lg==",
+      "dependencies": {
+        "@sanity/diff-match-patch": "^3.1.1",
+        "@sanity/types": "3.70.0",
+        "@sanity/uuid": "^3.0.1",
+        "debug": "^4.3.4",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/@sanity/types": {
+      "version": "3.70.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.70.0.tgz",
+      "integrity": "sha512-Qr2tk9Kr6VP2nL30w/wo+92NI/De+RmpMgkL9jY1hLLWYiGG1c3cJyR2pUK7iIwF3pUHwHPGV+S1APhw5XQ8zw==",
+      "dependencies": {
+        "@sanity/client": "^6.24.3"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sanity/import/node_modules/p-map": {
@@ -2759,6 +2947,24 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@sanity/import/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@sanity/logos": {
@@ -2774,14 +2980,14 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.36.4.tgz",
-      "integrity": "sha512-5zXOgrKUFYrvAf1qbyBsbvgIWUCAN/P2imV7aKWEU7RxkT5ks5DfR/UrcHTcnv8/kRYhuuc3smtaq6WFyxMvXA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.39.0.tgz",
+      "integrity": "sha512-muezFwxkc1mY3+WTJv+oxy3jtpwyvNQFegPXPmev7qUfVEV0rnarRUgGPVaaaHZalCwBgPugrOctNi9aS3Ja5A==",
       "dependencies": {
         "@bjoerge/mutiny": "^0.5.1",
-        "@sanity/client": "^6.15.7",
-        "@sanity/types": "3.36.4",
-        "@sanity/util": "3.36.4",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.39.0",
+        "@sanity/util": "3.39.0",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
@@ -2801,9 +3007,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.36.4.tgz",
-      "integrity": "sha512-0CpgPe6nrljsBMglHrEE14s5pWSJ76+rF44RnwDzznwRgm4NLSNUEgwbyFJ4EdD4nSJcDo+/OfYrBZX/Mhmb7w==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.39.0.tgz",
+      "integrity": "sha512-7T2mRoRpicmoEY5QhKUUp75zOLG5b+tpjPTBENVXry5PgXw7AqwMkJVM7oF1fC11S4R8e0yssnXVTcRwHRmKqw==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -2812,16 +3018,16 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.36.4.tgz",
-      "integrity": "sha512-iXSmV2Pl1nRdvjHb1rPeh2Rm7CEEFDoD44DWhuuZT3OP6gSwO8SI2CqySEZbnPJqQdBKhYqkDnt+g/2Yn6QTtw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.39.0.tgz",
+      "integrity": "sha512-LB443HNOi9+6VRD12tD2puwEc9hAGOCEZSm7IpXbgScfJY2iKjZSyC76CyoB5aSgZusjlRAVK0ozwhG5GnBQpA==",
       "dependencies": {
-        "@sanity/block-tools": "3.36.4",
-        "@sanity/schema": "3.36.4",
-        "@sanity/types": "3.36.4",
-        "@sanity/util": "3.36.4",
+        "@sanity/block-tools": "3.39.0",
+        "@sanity/schema": "3.39.0",
+        "@sanity/types": "3.39.0",
+        "@sanity/util": "3.39.0",
         "debug": "^3.2.7",
-        "is-hotkey": "^0.2.0",
+        "is-hotkey-esm": "^1.0.0",
         "lodash": "^4.17.21",
         "slate": "0.100.0",
         "slate-react": "0.101.0"
@@ -2832,7 +3038,7 @@
       "peerDependencies": {
         "react": "^16.9 || ^17 || ^18",
         "rxjs": "^7",
-        "styled-components": "^5.2 || ^6"
+        "styled-components": "^6.1"
       }
     },
     "node_modules/@sanity/portable-text-editor/node_modules/debug": {
@@ -2844,19 +3050,19 @@
       }
     },
     "node_modules/@sanity/presentation": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.12.1.tgz",
-      "integrity": "sha512-SpCt1Z4dCEfnFj+7fNZQUCWE3zucYQmKguKkLm36GoSdc4mEwMV0UPUSmgiW1oi/IcmdalDETCUqQBMQ2s3GEg==",
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.12.7.tgz",
+      "integrity": "sha512-qFISwEZkgQjuHtqio1TSgbCXapbVvZLiq+R9Y4ldngdrso6tAg/8SeI1DtSDEUCIV6ZK1ep8/5SzlUcz0Q9jIQ==",
       "dependencies": {
-        "@sanity/icons": "^2.11.4",
-        "@sanity/preview-url-secret": "^1.6.5",
-        "@sanity/ui": "^2.0.12",
+        "@sanity/icons": "^2.11.8",
+        "@sanity/preview-url-secret": "^1.6.11",
+        "@sanity/ui": "^2.1.4",
         "@sanity/uuid": "3.0.2",
         "@types/lodash.isequal": "^4.5.8",
         "fast-deep-equal": "3.1.3",
         "framer-motion": "11.0.8",
         "lodash.isequal": "^4.5.0",
-        "mendoza": "3.0.6",
+        "mendoza": "3.0.7",
         "mnemonist": "0.39.8",
         "rxjs": "^7.8.1",
         "suspend-react": "0.1.3"
@@ -2865,7 +3071,7 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.15.7"
+        "@sanity/client": "^6.15.20"
       }
     },
     "node_modules/@sanity/presentation/node_modules/framer-motion": {
@@ -2892,9 +3098,9 @@
       }
     },
     "node_modules/@sanity/presentation/node_modules/mendoza": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.6.tgz",
-      "integrity": "sha512-oTwuDUEiUjiffiWm1BHEw3E50x4tiyhm9CO0ximOKXyeLOIcEkbXltHCCOtTRcQ9eCkmjmfz4E9f9TSSQBI9Mw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.7.tgz",
+      "integrity": "sha512-KtLgsCl5dFjRPUVSVV9KxpUr2BfZgLv8uqxg/hCsI7JIWsesHABSbl0MQwxNHAg24KtzSQ6vrPsgeNnoq4UImg==",
       "engines": {
         "node": ">=14.18"
       }
@@ -2914,18 +3120,18 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.36.4.tgz",
-      "integrity": "sha512-ZqSwKma2imxvkoiMMoaALJKJOn78WGkd7Jtq5pqmdS/1laFkBpmRmcoaL+Vd8BCXeYjl5bnkF1JjEpijoedlfA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.39.0.tgz",
+      "integrity": "sha512-qxoL1UombdDYy/BaL5faKSdV2sr/DcvkuUWc7JLFaIpleeA2W7FWaIBZL22e5qdAdZqaq0im8XeQfX+WZPaFmw==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.36.4",
+        "@sanity/types": "3.39.0",
         "arrify": "^1.0.1",
         "groq-js": "^1.7.0",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
-        "object-inspect": "^1.6.0"
+        "object-inspect": "^1.13.1"
       }
     },
     "node_modules/@sanity/telemetry": {
@@ -2945,11 +3151,11 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.36.4.tgz",
-      "integrity": "sha512-UJ6Zrs258mvODOwvV2wIQ0XdhCiqi24OuRObPFYALeE0oVtWWHuSsljPhQ2rt1VHLTVdVHcvace4MvNM7lIraQ==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.39.0.tgz",
+      "integrity": "sha512-xTiNmvLnHML4CmbqOztak7DSFi46F9KW444+3TIX+8pRkbtF7mrTKmK+HgKLLU7tIx2N2L8Z/wdc7IfABayiMA==",
       "dependencies": {
-        "@sanity/client": "^6.15.7",
+        "@sanity/client": "^6.15.20",
         "@types/react": "^18.0.25"
       }
     },
@@ -2989,12 +3195,12 @@
       }
     },
     "node_modules/@sanity/util": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.36.4.tgz",
-      "integrity": "sha512-KoFjk+fHHLJ7Of9MGyYN1MjszvepTHb12qT240HG2DbTJkbDXK+C+Df55+MyRJYPoZuoDVEmKajoaP+GxeLHPA==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.39.0.tgz",
+      "integrity": "sha512-MJ16qJHG70CehPNz31H5wISvu7IYNMoI3wjQ3qOzQPALHyc0PbhxW03MNlmBw+Px3tWS+eYyPedpGTJT56o1SQ==",
       "dependencies": {
-        "@sanity/client": "^6.15.7",
-        "@sanity/types": "3.36.4",
+        "@sanity/client": "^6.15.20",
+        "@sanity/types": "3.39.0",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -3013,9 +3219,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.36.4.tgz",
-      "integrity": "sha512-wJB1TBZGRU9If+QK6I8nxKvzf1ihZZ7aWxOcMwMNhFWS5s0U8E70xkobIbJy9Wb6lfyka7GPIW9hcrWr8JHAhg==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.39.0.tgz",
+      "integrity": "sha512-vKZgsV+iAJ7FoIRAnqhLKGj/iNAb7BGFHv0y9cysLeN0+aBwp+jeTiVxszLq9nA8l991ddNwuHY8+S/m8BQJHg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -3030,16 +3236,16 @@
         "@rexxars/react-split-pane": "^0.1.93",
         "@sanity/color": "^3.0.0",
         "@sanity/icons": "^2.11.0",
-        "@sanity/ui": "^2.0.12",
+        "@sanity/ui": "^2.1.4",
         "@uiw/react-codemirror": "^4.11.4",
         "hashlru": "^2.3.0",
-        "is-hotkey": "^0.2.0",
+        "is-hotkey-esm": "^1.0.0",
         "json5": "^2.2.3",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "react": "^18",
-        "styled-components": "^5.2 || ^6"
+        "styled-components": "^6.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3160,6 +3366,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
     },
     "node_modules/@types/node": {
       "version": "20.5.9",
@@ -3316,6 +3527,11 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vvo/tzdb": {
+      "version": "6.158.0",
+      "resolved": "https://registry.npmjs.org/@vvo/tzdb/-/tzdb-6.158.0.tgz",
+      "integrity": "sha512-rtkoqtpUP3qXZkO8btrTxeoWemFsf3mPAdG6rgMT582LOMrYpPZZhtve3/VyonznUtP9SJ/UrEBTSPN07a7NHw=="
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3458,6 +3674,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/archiver-utils/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
     "node_modules/archiver-utils/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -3467,6 +3702,21 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3854,6 +4104,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
@@ -3948,14 +4222,39 @@
       }
     },
     "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -3968,6 +4267,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -4440,6 +4747,14 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/date-fns-tz": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
+      "peerDependencies": {
+        "date-fns": "2.x"
+      }
+    },
     "node_modules/date-now": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-1.0.1.tgz",
@@ -4459,6 +4774,37 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -4624,6 +4970,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -4638,6 +4995,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -5409,15 +5774,18 @@
         "node": ">=8"
       }
     },
-    "node_modules/golden-fleece": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/golden-fleece/-/golden-fleece-1.0.9.tgz",
-      "integrity": "sha512-YSwLaGMOgSBx9roJlNLL12c+FRiw7VECphinc6mGucphc/ZxTHgdEz6gmJqH6NOzYEd/yr64hwjom5pZ+tJVpg=="
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/groq": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.39.0.tgz",
+      "integrity": "sha512-b3VUixTuNYF51zGPQRUU5qzQVNy98igjJsVq7jm7cHtLX7n8JviZ3OoAnP1NgXqbbu7JJOj4WxZuPxsQkvGQiA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/groq-js": {
       "version": "1.14.2",
@@ -5444,6 +5812,14 @@
       },
       "bin": {
         "gunzip-maybe": "bin.js"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/has": {
@@ -5661,6 +6037,14 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -5802,6 +6186,19 @@
       "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
       "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
     },
+    "node_modules/is-hotkey-esm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey-esm/-/is-hotkey-esm-1.0.0.tgz",
+      "integrity": "sha512-eTXNmLCPXpKEZUERK6rmFsqmL66+5iNB998JMO+/61fSxBZFuUR1qHyFyx7ocBl5Vs8qjFzRAJLACpYfhS5g5w=="
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -5821,6 +6218,14 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -5874,6 +6279,17 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5904,17 +6320,17 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
+      "engines": {
+        "node": "20 || >=22"
+      },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/js-tokens": {
@@ -5994,6 +6410,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-reduce/-/json-reduce-3.0.0.tgz",
       "integrity": "sha512-zvnhEvwhqTOxBIcXnxvHvhqtubdwFRp+FascmCaL56BT9jdttRU8IFc+Ilh2HPJ0AtioF8mFPxmReuJKLW0Iyw=="
+    },
+    "node_modules/json-stream-stringify": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-2.0.4.tgz",
+      "integrity": "sha512-gIPoa6K5w6j/RnQ3fOtmvICKNJGViI83A7dnTIL+0QJ/1GKuNvCPFvbFWxt0agruF4iGgDFJvge4Gua4ZoiggQ=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6116,6 +6537,17 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/md5-o-matic": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
@@ -6126,17 +6558,97 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
-    "node_modules/memoize-resolver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-resolver/-/memoize-resolver-1.0.0.tgz",
-      "integrity": "sha512-mXfNXte0RSWl0rEIsQhXutfM2R2Oa7UyKDD7XoZMEbKeucTRms04y5y41U8gLqPzRx7ViN/QyYnTR2TX/5tawA=="
-    },
     "node_modules/mendoza": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/mendoza/-/mendoza-3.0.8.tgz",
       "integrity": "sha512-iwxgEpSOx9BDLJMD0JAzNicqo9xdrvzt6w/aVwBKMndlA6z/DH41+o60H2uHB0vCR1Xr37UOgu9xFWJHvYsuKw==",
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/meow/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {
@@ -6210,6 +6722,14 @@
         "dom-walk": "^0.1.0"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6229,12 +6749,126 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
+      "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minizlib/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/minizlib/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minizlib/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/minizlib/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/minizlib/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minizlib/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minizlib/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mississippi": {
@@ -6264,6 +6898,20 @@
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -6311,9 +6959,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nano-pubsub": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-2.0.1.tgz",
-      "integrity": "sha512-RWgGP2TdeKZLx+guR5a7/BzYs85sj6yrXXyj0o/znbgzPlz/Ez9wQuKDpwUZ8q+u2RxXpqZ1iTkPXCIU+GHhpA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nano-pubsub/-/nano-pubsub-3.0.0.tgz",
+      "integrity": "sha512-zoTNyBafxG0+F5PP3T3j1PKMr7gedriSdYRhLFLRFCz0OnQfQ6BkVk9peXVF30hz633Bw0Zh5McleOrXPjWYCQ==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -6456,6 +7107,130 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-finally": {
@@ -6632,24 +7407,27 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7012,6 +7790,14 @@
       "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
       "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -7273,6 +8059,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/refractor": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
@@ -7393,6 +8191,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7467,17 +8277,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs-etc": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/rxjs-etc/-/rxjs-etc-10.6.2.tgz",
-      "integrity": "sha512-OmXhrTsEqcIT4PX1TSf+iRsah3sjMEQ27z7aXCc96xwiKr18RWhvtxUyGnvKMBwF8AavwLXELAMKA8ImgKXeoA==",
-      "dependencies": {
-        "memoize-resolver": "~1.0.0"
-      },
-      "peerDependencies": {
-        "rxjs": "^6.0.0 || ^7.0.0"
-      }
-    },
     "node_modules/rxjs-exhaustmap-with-trailing": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/rxjs-exhaustmap-with-trailing/-/rxjs-exhaustmap-with-trailing-2.1.1.tgz",
@@ -7497,9 +8296,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.36.4",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.36.4.tgz",
-      "integrity": "sha512-2HCLd4T+VhTHyhDqdf5/VxEUEv1gfOZzGl4okksMfDekqmCDwzkp5e03X0M3D3GhYB6NWqpP+OvPwTJxzIxsSw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.39.0.tgz",
+      "integrity": "sha512-xO2e0RParRbnOD1y2nv5q4YIbhNz36k1D/pR+D1kZr1KJItn/CeWW4tGgpVeCnmZcRAUNp+xwHIjPS1XLlGpVA==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -7510,31 +8309,29 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
         "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.36.4",
-        "@sanity/cli": "3.36.4",
-        "@sanity/client": "^6.15.7",
+        "@sanity/block-tools": "3.39.0",
+        "@sanity/cli": "3.39.0",
+        "@sanity/client": "^6.15.20",
         "@sanity/color": "^3.0.0",
-        "@sanity/diff": "3.36.4",
+        "@sanity/diff": "3.39.0",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "3.36.4",
-        "@sanity/generate-help-url": "^3.0.0",
+        "@sanity/export": "^3.37.4",
         "@sanity/icons": "^2.11.0",
         "@sanity/image-url": "^1.0.2",
-        "@sanity/import": "3.36.4",
+        "@sanity/import": "^3.37.3",
         "@sanity/logos": "^2.1.4",
-        "@sanity/migrate": "3.36.4",
-        "@sanity/mutator": "3.36.4",
-        "@sanity/portable-text-editor": "3.36.4",
-        "@sanity/presentation": "1.12.1",
-        "@sanity/schema": "3.36.4",
+        "@sanity/migrate": "3.39.0",
+        "@sanity/mutator": "3.39.0",
+        "@sanity/portable-text-editor": "3.39.0",
+        "@sanity/presentation": "1.12.7",
+        "@sanity/schema": "3.39.0",
         "@sanity/telemetry": "^0.7.6",
-        "@sanity/types": "3.36.4",
-        "@sanity/ui": "^2.0.12",
-        "@sanity/util": "3.36.4",
+        "@sanity/types": "3.39.0",
+        "@sanity/ui": "^2.1.4",
+        "@sanity/util": "3.39.0",
         "@sanity/uuid": "^3.0.1",
         "@tanstack/react-virtual": "3.0.0-beta.54",
-        "@types/is-hotkey": "^0.1.7",
         "@types/react-copy-to-clipboard": "^5.0.2",
         "@types/react-is": "^18.2.0",
         "@types/shallow-equals": "^1.0.0",
@@ -7542,6 +8339,7 @@
         "@types/tar-stream": "^3.1.3",
         "@types/use-sync-external-store": "^0.0.6",
         "@vitejs/plugin-react": "^4.2.1",
+        "@vvo/tzdb": "^6.131.0",
         "archiver": "^7.0.0",
         "arrify": "^1.0.1",
         "async-mutex": "^0.4.1",
@@ -7554,20 +8352,21 @@
         "console-table-printer": "^2.11.1",
         "dataloader": "^2.1.0",
         "date-fns": "^2.26.1",
+        "date-fns-tz": "^2.0.0",
         "debug": "^4.3.4",
         "esbuild": "^0.20.0",
         "esbuild-register": "^3.4.1",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
-        "framer-motion": "^11.0.0",
-        "get-it": "^8.4.16",
+        "framer-motion": "11.0.8",
+        "get-it": "^8.4.27",
         "get-random-values-esm": "1.0.2",
         "groq-js": "^1.7.0",
         "hashlru": "^2.3.0",
         "history": "^5.3.0",
         "i18next": "^23.2.7",
         "import-fresh": "^3.3.0",
-        "is-hotkey": "^0.2.0",
+        "is-hotkey-esm": "^1.0.0",
         "jsdom": "^23.0.1",
         "jsdom-global": "^3.0.2",
         "json-lexer": "^1.2.0",
@@ -7577,7 +8376,7 @@
         "log-symbols": "^2.2.0",
         "mendoza": "^3.0.0",
         "module-alias": "^2.2.2",
-        "nano-pubsub": "^2.0.1",
+        "nano-pubsub": "^3.0.0",
         "nanoid": "^3.1.30",
         "observable-callback": "^1.0.1",
         "oneline": "^1.0.3",
@@ -7600,17 +8399,17 @@
         "resolve-from": "^5.0.0",
         "rimraf": "^3.0.2",
         "rxjs": "^7.8.0",
-        "rxjs-etc": "^10.6.0",
         "rxjs-exhaustmap-with-trailing": "^2.1.1",
         "sanity-diff-patch": "^3.0.2",
         "scroll-into-view-if-needed": "^3.0.3",
         "semver": "^7.3.5",
         "shallow-equals": "^1.0.0",
         "speakingurl": "^14.0.1",
+        "swr": "^2.2.5",
         "tar-fs": "^2.1.1",
         "tar-stream": "^3.1.7",
         "use-device-pixel-ratio": "^1.1.0",
-        "use-hot-module-reload": "^1.0.1",
+        "use-hot-module-reload": "^2.0.0",
         "use-sync-external-store": "^1.2.0",
         "vite": "^4.5.1",
         "yargs": "^17.3.0"
@@ -7624,7 +8423,7 @@
       "peerDependencies": {
         "react": "^18",
         "react-dom": "^18",
-        "styled-components": "^5.2 || ^6"
+        "styled-components": "^6.1"
       }
     },
     "node_modules/sanity-diff-patch": {
@@ -7682,6 +8481,29 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/sanity/node_modules/framer-motion": {
+      "version": "11.0.8",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.8.tgz",
+      "integrity": "sha512-1KSGNuqe1qZkS/SWQlDnqK2VCVzRVEoval379j0FiUBJAZoqgwyvqFkfvJbgW2IPFo4wX16K+M0k5jO23lCIjA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/sanity/node_modules/has-flag": {
       "version": "4.0.0",
@@ -7842,6 +8664,11 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/silver-fleece": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/silver-fleece/-/silver-fleece-1.1.0.tgz",
+      "integrity": "sha512-V3vShUiLRVPMu9aSWpU5kLDoU/HO7muJKE236EO663po3YxivAkMLbRg+amV/FhbIfF5bWXX5TVX+VYmRaOBFA=="
     },
     "node_modules/simple-wcswidth": {
       "version": "1.0.1",
@@ -8095,6 +8922,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.2.tgz",
@@ -8202,10 +9040,38 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
+      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tar-fs": {
       "version": "2.1.2",
@@ -8227,6 +9093,11 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/tar-fs/node_modules/readable-stream": {
       "version": "3.6.2",
@@ -8273,6 +9144,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
@@ -8304,6 +9183,42 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/to-buffer": {
       "version": "1.1.1",
@@ -8349,6 +9264,14 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -8578,9 +9501,9 @@
       }
     },
     "node_modules/use-hot-module-reload": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/use-hot-module-reload/-/use-hot-module-reload-1.0.3.tgz",
-      "integrity": "sha512-Wk/sjFhOF+a6PkovJvDAT3c8yE1DluZsSB3L+gTS8pM4ht2yg/LqBj4YLwnYJSdPnFqGWvu93CMdso8bcKw36A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/use-hot-module-reload/-/use-hot-module-reload-2.0.0.tgz",
+      "integrity": "sha512-RbL/OY1HjHNf5BYSFV3yDtQhIGKjCx9ntEjnUBYsOGc9fTo94nyFTcjtD42/twJkPgMljWpszUIpTGD3LuwHSg==",
       "peerDependencies": {
         "react": ">=17.0.0"
       }
@@ -8607,11 +9530,11 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9096,6 +10019,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -9327,6 +10258,17 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@sanity/cli": "3.39.0",
-        "@sanity/vision": "3.39.0",
+        "@sanity/cli": "3.48.1",
+        "@sanity/vision": "3.48.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-icons": "5.3.0",
-        "sanity": "3.39.0",
+        "sanity": "3.48.1",
         "short-uuid": "4.2.2",
         "styled-components": "^6.1.14"
       }
@@ -1834,9 +1834,9 @@
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1849,9 +1849,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
@@ -1879,9 +1879,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
@@ -1894,9 +1894,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -1909,9 +1909,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
@@ -1924,9 +1924,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1939,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
@@ -1954,9 +1954,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
@@ -1969,9 +1969,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
@@ -1984,9 +1984,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
@@ -1999,9 +1999,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
@@ -2029,9 +2029,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
@@ -2059,9 +2059,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
@@ -2074,9 +2074,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -2089,9 +2089,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
@@ -2119,9 +2119,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
@@ -2134,9 +2134,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
@@ -2164,9 +2164,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
@@ -2509,18 +2509,18 @@
       }
     },
     "node_modules/@sanity/bifur-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@sanity/bifur-client/-/bifur-client-0.3.1.tgz",
-      "integrity": "sha512-GlY9+tUmM0Vye64BHwIYLOivuRL37ucW/sj/D9MYqBmjgBnTRrjfmg8NR7qoodZuJ5nYJ5qpGMsVIBLP4Plvnw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sanity/bifur-client/-/bifur-client-0.4.1.tgz",
+      "integrity": "sha512-mHM8WR7pujbIw2qxuV0lzinS1izOoyLza/ejWV6quITTLpBhUoPIQGPER3Ar0SON5JV0VEEqkJGa1kjiYYgx2w==",
       "dependencies": {
         "nanoid": "^3.1.12",
         "rxjs": "^7.0.0"
       }
     },
     "node_modules/@sanity/block-tools": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.39.0.tgz",
-      "integrity": "sha512-tDjpqyqLkOGgY9UWd9fWFht9F8DQ+bZqppyHoP2LkSusVdMsMjVx4tCNZJSIvnyUiqEHWHlQ8muALNduCSAQDg==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.48.1.tgz",
+      "integrity": "sha512-I43M1zdUFAK32+Pd6uQptcx0Myv+dwDAqVvWWgQMqeXrBxm9u9SmA2k/0+EE25XW9wJ/pk60qKcDNhBl+biX+g==",
       "deprecated": "Renamed - use `@portabletext/block-tools` instead. `@sanity/block-tools` will no longer receive updates.",
       "dependencies": {
         "get-random-values-esm": "1.0.2",
@@ -2528,24 +2528,25 @@
       }
     },
     "node_modules/@sanity/cli": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.39.0.tgz",
-      "integrity": "sha512-YJSRcdniZnBFzNssVw1qNYLo4/IqXPSYYWDHkA0928nh2aPf3HjK599sSWfyJmmW2lIERWz8WPJcZ7OWxNgpgA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-3.48.1.tgz",
+      "integrity": "sha512-rPDP2nnup1c9HsHc4IUQh6XC3OVAkLLqXCjUlDSTQZcCwmUhLwy88GRvcFGhsWAQgQ6AIXkjZjz84uLMMkSxBw==",
       "dependencies": {
         "@babel/traverse": "^7.23.5",
-        "@sanity/client": "^6.15.20",
-        "@sanity/codegen": "3.39.0",
-        "@sanity/telemetry": "^0.7.6",
-        "@sanity/util": "3.39.0",
+        "@sanity/client": "^6.20.0",
+        "@sanity/codegen": "3.48.1",
+        "@sanity/telemetry": "^0.7.7",
+        "@sanity/util": "3.48.1",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "decompress": "^4.2.0",
-        "esbuild": "^0.20.0",
+        "esbuild": "^0.21.0",
         "esbuild-register": "^3.4.1",
-        "get-it": "^8.4.27",
-        "groq-js": "^1.7.0",
+        "get-it": "^8.6.0",
+        "groq-js": "^1.9.0",
         "node-machine-id": "^1.1.12",
         "pkg-dir": "^5.0.0",
+        "prettier": "^3.3.0",
         "semver": "^7.3.5",
         "silver-fleece": "1.1.0",
         "validate-npm-package-name": "^3.0.0"
@@ -2635,9 +2636,9 @@
       }
     },
     "node_modules/@sanity/codegen": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.39.0.tgz",
-      "integrity": "sha512-ab42ElTO5Bu8TeU/IPYlwe9bRXsV05LMDPPqBDN+70egGJ1LB3s/FNwhC2e0LM+t89Qha8VFAFOUadmaru+ddA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/codegen/-/codegen-3.48.1.tgz",
+      "integrity": "sha512-FuWMe32Dd9Gdamm0FD6EmjGBVw2Sd6h5IrxYQLJGggYTaamnkDYFxQjA4LosI3A9rPRU/du8SrljI5twrfxlfA==",
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/generator": "^7.23.6",
@@ -2649,8 +2650,8 @@
         "@babel/types": "^7.23.9",
         "debug": "^4.3.4",
         "globby": "^10.0.0",
-        "groq": "3.39.0",
-        "groq-js": "^1.7.0",
+        "groq": "3.48.1",
+        "groq-js": "^1.9.0",
         "json5": "^2.2.3",
         "tsconfig-paths": "^4.2.0",
         "zod": "^3.22.4"
@@ -2668,9 +2669,9 @@
       }
     },
     "node_modules/@sanity/diff": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.39.0.tgz",
-      "integrity": "sha512-Z098rcSq3W3VgXABSmnI8+kop4KifK66MDbp1Kl8sY9VBa7kU3lTEts9Fnr+vNI1AoaD7XSBAlW6FcplQMBCjQ==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/diff/-/diff-3.48.1.tgz",
+      "integrity": "sha512-urL9XFoHt7f5OEw0Ql05eX9V7aZHhcruKDH+mKZZdgW5aVz2xYzzrRjm6MkvJHC0PjQRngYrtSnU3GTZw/PWLg==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1"
       },
@@ -2814,14 +2815,14 @@
       "integrity": "sha512-wtMYcV5GIDIhVyF/jjmdwq1GdlK07dRL40XMns73VbrFI7FteRltxv48bhYVZPcLkRXb0SHjpDS/icj9/yzbVA=="
     },
     "node_modules/@sanity/icons": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
-      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.5.7.tgz",
+      "integrity": "sha512-Gdqh1Cst/GL2RF23Ztx14hFEOBltK7PYMDHTi83TQ4Vq2/W0rhhMTVlaAopb4MgnUBwzISHRLD85SuvDMi9SuA==",
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": "^18"
+        "react": "^18.3 || ^19.0.0-0"
       }
     },
     "node_modules/@sanity/image-url": {
@@ -2967,6 +2968,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@sanity/insert-menu": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@sanity/insert-menu/-/insert-menu-1.0.6.tgz",
+      "integrity": "sha512-qvDj/hX2bLulgkD8ksXRwJa/xxtck7UKTBwIVqmWS2jq5bLdG+1D5K8pIEb24KI6VFkgPCrIkygX/pU+2HatWA==",
+      "dependencies": {
+        "@sanity/icons": "^3.2.0",
+        "@sanity/ui": "^2.3.3",
+        "lodash.startcase": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@sanity/types": "^3.45.0",
+        "react": "^18.3 || >=19.0.0-rc",
+        "react-dom": "^18.3 || >=19.0.0-rc",
+        "react-is": "^18.3 || >=19.0.0-rc"
+      }
+    },
     "node_modules/@sanity/logos": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@sanity/logos/-/logos-2.1.13.tgz",
@@ -2980,18 +3000,18 @@
       }
     },
     "node_modules/@sanity/migrate": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.39.0.tgz",
-      "integrity": "sha512-muezFwxkc1mY3+WTJv+oxy3jtpwyvNQFegPXPmev7qUfVEV0rnarRUgGPVaaaHZalCwBgPugrOctNi9aS3Ja5A==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/migrate/-/migrate-3.48.1.tgz",
+      "integrity": "sha512-hZF9W871nTN8g9/ZdSZMDO6PWawTOD+HGO0yGIj5keE3IP5o+8EuoffgJHuVghqe/31kU1XvT887IUNNLaFd+Q==",
       "dependencies": {
         "@bjoerge/mutiny": "^0.5.1",
-        "@sanity/client": "^6.15.20",
-        "@sanity/types": "3.39.0",
-        "@sanity/util": "3.39.0",
+        "@sanity/client": "^6.20.0",
+        "@sanity/types": "3.48.1",
+        "@sanity/util": "3.48.1",
         "arrify": "^2.0.1",
         "debug": "^4.3.4",
         "fast-fifo": "^1.3.2",
-        "groq-js": "^1.7.0",
+        "groq-js": "^1.9.0",
         "p-map": "^7.0.1"
       },
       "engines": {
@@ -3007,9 +3027,9 @@
       }
     },
     "node_modules/@sanity/mutator": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.39.0.tgz",
-      "integrity": "sha512-7T2mRoRpicmoEY5QhKUUp75zOLG5b+tpjPTBENVXry5PgXw7AqwMkJVM7oF1fC11S4R8e0yssnXVTcRwHRmKqw==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/mutator/-/mutator-3.48.1.tgz",
+      "integrity": "sha512-1+eCk29pWz1Fmssxq/A7oveEagEM9JcwdlfENNSnvY5cPB38KA1LYlNBCPykSCl8hC1/19EdyUgrlTNdf5gndQ==",
       "dependencies": {
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/uuid": "^3.0.1",
@@ -3018,14 +3038,14 @@
       }
     },
     "node_modules/@sanity/portable-text-editor": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.39.0.tgz",
-      "integrity": "sha512-LB443HNOi9+6VRD12tD2puwEc9hAGOCEZSm7IpXbgScfJY2iKjZSyC76CyoB5aSgZusjlRAVK0ozwhG5GnBQpA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/portable-text-editor/-/portable-text-editor-3.48.1.tgz",
+      "integrity": "sha512-0GNWlfTQeY0TwUlOLvjy9vYAVrRbhDcrmZ9nOXJYWcNVhG2K8GyT+MpPNEOOm+DwE75m1XXTUd3w2UX1VqXLtQ==",
       "dependencies": {
-        "@sanity/block-tools": "3.39.0",
-        "@sanity/schema": "3.39.0",
-        "@sanity/types": "3.39.0",
-        "@sanity/util": "3.39.0",
+        "@sanity/block-tools": "3.48.1",
+        "@sanity/schema": "3.48.1",
+        "@sanity/types": "3.48.1",
+        "@sanity/util": "3.48.1",
         "debug": "^3.2.7",
         "is-hotkey-esm": "^1.0.0",
         "lodash": "^4.17.21",
@@ -3050,20 +3070,22 @@
       }
     },
     "node_modules/@sanity/presentation": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.12.7.tgz",
-      "integrity": "sha512-qFISwEZkgQjuHtqio1TSgbCXapbVvZLiq+R9Y4ldngdrso6tAg/8SeI1DtSDEUCIV6ZK1ep8/5SzlUcz0Q9jIQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@sanity/presentation/-/presentation-1.16.0.tgz",
+      "integrity": "sha512-8nNGPM+r+D8dRe/UVcDEO6Z9gzS5LcOIQMzziOg8nMUGz284pcuEIzvRI9XQ3gbMiv6Zyo+fzuJPktoq+dkqhw==",
       "dependencies": {
-        "@sanity/icons": "^2.11.8",
-        "@sanity/preview-url-secret": "^1.6.11",
-        "@sanity/ui": "^2.1.4",
+        "@sanity/icons": "^3.2.0",
+        "@sanity/preview-url-secret": "^1.6.17",
+        "@sanity/ui": "^2.3.3",
         "@sanity/uuid": "3.0.2",
         "@types/lodash.isequal": "^4.5.8",
         "fast-deep-equal": "3.1.3",
         "framer-motion": "11.0.8",
+        "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "mendoza": "3.0.7",
         "mnemonist": "0.39.8",
+        "path-to-regexp": "^6.2.2",
         "rxjs": "^7.8.1",
         "suspend-react": "0.1.3"
       },
@@ -3071,7 +3093,7 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@sanity/client": "^6.15.20"
+        "@sanity/client": "^6.19.1"
       }
     },
     "node_modules/@sanity/presentation/node_modules/framer-motion": {
@@ -3120,14 +3142,14 @@
       }
     },
     "node_modules/@sanity/schema": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.39.0.tgz",
-      "integrity": "sha512-qxoL1UombdDYy/BaL5faKSdV2sr/DcvkuUWc7JLFaIpleeA2W7FWaIBZL22e5qdAdZqaq0im8XeQfX+WZPaFmw==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-3.48.1.tgz",
+      "integrity": "sha512-d5psPHa0PD36jLiU7gjftYNRxqyyNQE3aj55u3yu8a6Bdp9uw2XVQjz2r0dnmOEIGOYIcUK7CSnpbEsuv+mhQA==",
       "dependencies": {
         "@sanity/generate-help-url": "^3.0.0",
-        "@sanity/types": "3.39.0",
+        "@sanity/types": "3.48.1",
         "arrify": "^1.0.1",
-        "groq-js": "^1.7.0",
+        "groq-js": "^1.9.0",
         "humanize-list": "^1.0.1",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
@@ -3151,11 +3173,11 @@
       }
     },
     "node_modules/@sanity/types": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.39.0.tgz",
-      "integrity": "sha512-xTiNmvLnHML4CmbqOztak7DSFi46F9KW444+3TIX+8pRkbtF7mrTKmK+HgKLLU7tIx2N2L8Z/wdc7IfABayiMA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.48.1.tgz",
+      "integrity": "sha512-UG+AjRPYhh+URH5pBrIQ4h81rRbVZ+J/WLL+vP9uL/bseq61etWIYz8iljXWuReVHbqBPLGHQF1EpcMX1EZ5MQ==",
       "dependencies": {
-        "@sanity/client": "^6.15.20",
+        "@sanity/client": "^6.20.0",
         "@types/react": "^18.0.25"
       }
     },
@@ -3183,24 +3205,13 @@
         "styled-components": "^5.2 || ^6"
       }
     },
-    "node_modules/@sanity/ui/node_modules/@sanity/icons": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.5.7.tgz",
-      "integrity": "sha512-Gdqh1Cst/GL2RF23Ztx14hFEOBltK7PYMDHTi83TQ4Vq2/W0rhhMTVlaAopb4MgnUBwzISHRLD85SuvDMi9SuA==",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3 || ^19.0.0-0"
-      }
-    },
     "node_modules/@sanity/util": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.39.0.tgz",
-      "integrity": "sha512-MJ16qJHG70CehPNz31H5wISvu7IYNMoI3wjQ3qOzQPALHyc0PbhxW03MNlmBw+Px3tWS+eYyPedpGTJT56o1SQ==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/util/-/util-3.48.1.tgz",
+      "integrity": "sha512-MTWKGuE88ASGnx9nngqAd0ZphVXppCIIgh5KB/xvMDigaWcrP5tWW34XR6yN52/6kRHGxU2ehyC7RRZDMTj9pQ==",
       "dependencies": {
-        "@sanity/client": "^6.15.20",
-        "@sanity/types": "3.39.0",
+        "@sanity/client": "^6.20.0",
+        "@sanity/types": "3.48.1",
         "get-random-values-esm": "1.0.2",
         "moment": "^2.29.4",
         "rxjs": "^7.8.1"
@@ -3219,9 +3230,9 @@
       }
     },
     "node_modules/@sanity/vision": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.39.0.tgz",
-      "integrity": "sha512-vKZgsV+iAJ7FoIRAnqhLKGj/iNAb7BGFHv0y9cysLeN0+aBwp+jeTiVxszLq9nA8l991ddNwuHY8+S/m8BQJHg==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/@sanity/vision/-/vision-3.48.1.tgz",
+      "integrity": "sha512-ST3tCswZGbsf+uitzTP/WRPrwzsWFZcx4q+AEyKBZlftOjzqs0p9PWfxo38cRlquSp7I+9+Ga//URLCcUIekHA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.1.0",
         "@codemirror/commands": "^6.0.1",
@@ -3235,17 +3246,133 @@
         "@rexxars/react-json-inspector": "^8.0.1",
         "@rexxars/react-split-pane": "^0.1.93",
         "@sanity/color": "^3.0.0",
-        "@sanity/icons": "^2.11.0",
-        "@sanity/ui": "^2.1.4",
+        "@sanity/icons": "^3.0.0",
+        "@sanity/ui": "^2.4.0",
         "@uiw/react-codemirror": "^4.11.4",
-        "hashlru": "^2.3.0",
         "is-hotkey-esm": "^1.0.0",
+        "json-2-csv": "^5.5.1",
         "json5": "^2.2.3",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "quick-lru": "^5.1.1"
       },
       "peerDependencies": {
         "react": "^18",
         "styled-components": "^6.1"
+      }
+    },
+    "node_modules/@sanity/vision/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.49.0.tgz",
+      "integrity": "sha512-XkPHHdFqsN7EPaB+QGUOEmpFqXiqP67t2rRZ1HG1UwJoe0PhJEKNy7b4+WRwmT7ODSt+PvFk1gNBlJBpThwH7Q==",
+      "dependencies": {
+        "@sentry/core": "8.49.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.49.0.tgz",
+      "integrity": "sha512-v/wf7WvPxEvZUB7xrCnecI3fhevVo84hw8WlxgZIz6mLUHXEIX8xYWc9H8Yet/KKJ2uEB8GQ8aDsY6S1hVEIUA==",
+      "dependencies": {
+        "@sentry/core": "8.49.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.49.0.tgz",
+      "integrity": "sha512-BDiiCBxskkktTd6FNplBc9V8l14R4T/AwRIZj2itX4xnuHewTTDjVbeyvGol4roA4r+V0Mzoi31hLEGI6yFQ5Q==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.49.0",
+        "@sentry/core": "8.49.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.49.0.tgz",
+      "integrity": "sha512-/yXxI7f+Wu24FIYoRE7A0AidNxORuhAyPzb5ey1wFqMXP72nG8dXhOpcl0w+bi554FkqkLjdeUDhSOBWYZXH9g==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.49.0",
+        "@sentry/core": "8.49.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.49.0.tgz",
+      "integrity": "sha512-dS4Sw2h8EixHeXOIR++XEVMTen6xCGcIQ/XhJbsjqvddXeIijW0WkxSeTfPkfs0dsqFHSisWmlmo0xhHbXvEsQ==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.49.0",
+        "@sentry-internal/feedback": "8.49.0",
+        "@sentry-internal/replay": "8.49.0",
+        "@sentry-internal/replay-canvas": "8.49.0",
+        "@sentry/core": "8.49.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.49.0.tgz",
+      "integrity": "sha512-/OAm6LdHhh8TvfDAucWfSJV7M03IOHrJm5LVjrrKr4gwQ1HKd4CDbARsBbPwHIzSRAle0IgG3sbJxEvv52JUIw==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.49.0.tgz",
+      "integrity": "sha512-yBMEqiUcN05Sv9CCb4YkvgyIvgLdgecBoZOazJLBiSQ6znoP4oiUfFNDi2TUk46gzqrttuOU0jfT1AVBJ2xgKQ==",
+      "dependencies": {
+        "@sentry/browser": "8.49.0",
+        "@sentry/core": "8.49.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.20.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.20.6.tgz",
+      "integrity": "sha512-w0jluT718MrOKthRcr2xsjqzx+oEM7B7s/XXyfs19ll++hlId3fjTm+B2zrR3ijpANpkzBAr15j1XGVOMxpggQ==",
+      "dependencies": {
+        "@tanstack/table-core": "8.20.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -3261,6 +3388,18 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.20.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.20.5.tgz",
+      "integrity": "sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -3526,11 +3665,6 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0"
       }
-    },
-    "node_modules/@vvo/tzdb": {
-      "version": "6.158.0",
-      "resolved": "https://registry.npmjs.org/@vvo/tzdb/-/tzdb-6.158.0.tgz",
-      "integrity": "sha512-rtkoqtpUP3qXZkO8btrTxeoWemFsf3mPAdG6rgMT582LOMrYpPZZhtve3/VyonznUtP9SJ/UrEBTSPN07a7NHw=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -3976,6 +4110,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4662,6 +4801,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -4682,6 +4836,17 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssstyle": {
@@ -4745,14 +4910,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
-      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
-      "peerDependencies": {
-        "date-fns": "2.x"
       }
     },
     "node_modules/date-now": {
@@ -4970,6 +5127,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/deeks": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.1.0.tgz",
+      "integrity": "sha512-e7oWH1LzIdv/prMQ7pmlDlaVoL64glqzvNgkgQNgyec9ORPHrT2jaOqMtRyqJuwWjtfb6v+2rk9pmaHj+F137A==",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -4995,14 +5160,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -5038,10 +5195,69 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/doc-path": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.1.tgz",
+      "integrity": "sha512-h1ErTglQAVv2gCnOpD3sFS6uolDbOKHDU1BZq+Kl3npPqroU3dYL42lUgMfd5UimlwtRgp7C9dLGwqQ5D2HYgQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -5121,9 +5337,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -5132,29 +5348,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/esbuild-register": {
@@ -5780,9 +5996,9 @@
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/groq": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/groq/-/groq-3.39.0.tgz",
-      "integrity": "sha512-b3VUixTuNYF51zGPQRUU5qzQVNy98igjJsVq7jm7cHtLX7n8JviZ3OoAnP1NgXqbbu7JJOj4WxZuPxsQkvGQiA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/groq/-/groq-3.48.1.tgz",
+      "integrity": "sha512-GwPCG/pfBAMXBr3TyZdgM2cBSq86bHAME9OgV7E1pB4ohRkX9Y9vovvTanqaNsepQw3FAFH9bjwGG/bbwlHHoQ==",
       "engines": {
         "node": ">=18"
       }
@@ -5841,11 +6057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
     "node_modules/hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
@@ -5871,6 +6082,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/history": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
@@ -5878,6 +6097,19 @@
       "dependencies": {
         "@babel/runtime": "^7.7.6"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -6396,6 +6628,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-2-csv": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.7.tgz",
+      "integrity": "sha512-aZ0EOadeNnO4ifF60oXXTH8P177WeHhFLbRLqILW1Kk1gNHlgAOuvddMwEIaxbLpCzx+vXo49whK6AILdg8qLg==",
+      "dependencies": {
+        "deeks": "3.1.0",
+        "doc-path": "4.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/json-lexer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/json-lexer/-/json-lexer-1.2.0.tgz",
@@ -6480,10 +6724,20 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
     },
     "node_modules/log-symbols": {
       "version": "2.2.0",
@@ -6983,6 +7237,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-machine-id": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
@@ -7031,6 +7294,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7056,11 +7330,14 @@
       "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw=="
     },
     "node_modules/observable-callback": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.2.tgz",
-      "integrity": "sha512-Fb7qVUHqr8jl32NyJffTiqf76NObRvmzaSPgGtaAGH+Wfh45tiGWjrvUsNgEuCa86SUzGZZpoSN0hpGtldoSDg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.3.tgz",
+      "integrity": "sha512-VlS275UyPnwdMtzxDgr/lCiOUyq9uXNll3vdwzDcJ6PB/LuO7gLmxAQopcCA3JoFwwujBwyA7/tP5TXZwWSXew==",
+      "engines": {
+        "node": ">=16"
+      },
       "peerDependencies": {
-        "rxjs": "^6.5 || 7"
+        "rxjs": "^6.5 || ^7"
       }
     },
     "node_modules/once": {
@@ -7429,6 +7706,11 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -7637,6 +7919,20 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
@@ -7949,16 +8245,16 @@
       }
     },
     "node_modules/react-rx": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-2.1.3.tgz",
-      "integrity": "sha512-4dppkgEFAldr75IUUz14WyxuI2cJhpXYrrIM+4gvG6slKzaMUCmcgiiykx9Hst0UmtwNt247nRoOFDmN0Q7GJw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-rx/-/react-rx-3.1.3.tgz",
+      "integrity": "sha512-ITYuqiathSqLJjMvIO5kDDMSTDuvzpxebiDWNKIVMlGpvJxRXnnlwcQhlMcjV2Yr8+fNQHOHdf6fO/zS9+SMGw==",
       "dependencies": {
-        "observable-callback": "^1.0.2",
-        "use-sync-external-store": "^1.2.0"
+        "observable-callback": "^1.0.3",
+        "use-effect-event": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "rxjs": "^6.5 || ^7"
+        "react": "^18.3 || >=19.0.0-rc",
+        "rxjs": "^7"
       }
     },
     "node_modules/react-style-proptype": {
@@ -8296,9 +8592,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanity": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.39.0.tgz",
-      "integrity": "sha512-xO2e0RParRbnOD1y2nv5q4YIbhNz36k1D/pR+D1kZr1KJItn/CeWW4tGgpVeCnmZcRAUNp+xwHIjPS1XLlGpVA==",
+      "version": "3.48.1",
+      "resolved": "https://registry.npmjs.org/sanity/-/sanity-3.48.1.tgz",
+      "integrity": "sha512-Y26DX7AAvICJ0C4p4f83OhFpoW9ju4ZZZzfhd3SDB6FYN09D5pvmNEUFfXYd3HqONYwUGXurGsvbxq3bFjCKKQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.0.5",
         "@dnd-kit/modifiers": "^6.0.0",
@@ -8308,29 +8604,32 @@
         "@portabletext/react": "^3.0.0",
         "@rexxars/react-json-inspector": "^8.0.1",
         "@sanity/asset-utils": "^1.2.5",
-        "@sanity/bifur-client": "^0.3.1",
-        "@sanity/block-tools": "3.39.0",
-        "@sanity/cli": "3.39.0",
-        "@sanity/client": "^6.15.20",
+        "@sanity/bifur-client": "^0.4.0",
+        "@sanity/block-tools": "3.48.1",
+        "@sanity/cli": "3.48.1",
+        "@sanity/client": "^6.20.0",
         "@sanity/color": "^3.0.0",
-        "@sanity/diff": "3.39.0",
+        "@sanity/diff": "3.48.1",
         "@sanity/diff-match-patch": "^3.1.1",
         "@sanity/eventsource": "^5.0.0",
-        "@sanity/export": "^3.37.4",
-        "@sanity/icons": "^2.11.0",
+        "@sanity/export": "^3.38.2",
+        "@sanity/icons": "^3.0.0",
         "@sanity/image-url": "^1.0.2",
         "@sanity/import": "^3.37.3",
+        "@sanity/insert-menu": "1.0.6",
         "@sanity/logos": "^2.1.4",
-        "@sanity/migrate": "3.39.0",
-        "@sanity/mutator": "3.39.0",
-        "@sanity/portable-text-editor": "3.39.0",
-        "@sanity/presentation": "1.12.7",
-        "@sanity/schema": "3.39.0",
-        "@sanity/telemetry": "^0.7.6",
-        "@sanity/types": "3.39.0",
-        "@sanity/ui": "^2.1.4",
-        "@sanity/util": "3.39.0",
+        "@sanity/migrate": "3.48.1",
+        "@sanity/mutator": "3.48.1",
+        "@sanity/portable-text-editor": "3.48.1",
+        "@sanity/presentation": "1.16.0",
+        "@sanity/schema": "3.48.1",
+        "@sanity/telemetry": "^0.7.7",
+        "@sanity/types": "3.48.1",
+        "@sanity/ui": "^2.4.0",
+        "@sanity/util": "3.48.1",
         "@sanity/uuid": "^3.0.1",
+        "@sentry/react": "^8.7.0",
+        "@tanstack/react-table": "^8.16.0",
         "@tanstack/react-virtual": "3.0.0-beta.54",
         "@types/react-copy-to-clipboard": "^5.0.2",
         "@types/react-is": "^18.2.0",
@@ -8339,7 +8638,6 @@
         "@types/tar-stream": "^3.1.3",
         "@types/use-sync-external-store": "^0.0.6",
         "@vitejs/plugin-react": "^4.2.1",
-        "@vvo/tzdb": "^6.131.0",
         "archiver": "^7.0.0",
         "arrify": "^1.0.1",
         "async-mutex": "^0.4.1",
@@ -8352,17 +8650,15 @@
         "console-table-printer": "^2.11.1",
         "dataloader": "^2.1.0",
         "date-fns": "^2.26.1",
-        "date-fns-tz": "^2.0.0",
         "debug": "^4.3.4",
-        "esbuild": "^0.20.0",
+        "esbuild": "^0.21.0",
         "esbuild-register": "^3.4.1",
         "execa": "^2.0.0",
         "exif-component": "^1.0.1",
         "framer-motion": "11.0.8",
-        "get-it": "^8.4.27",
+        "get-it": "^8.6.0",
         "get-random-values-esm": "1.0.2",
-        "groq-js": "^1.7.0",
-        "hashlru": "^2.3.0",
+        "groq-js": "^1.9.0",
         "history": "^5.3.0",
         "i18next": "^23.2.7",
         "import-fresh": "^3.3.0",
@@ -8378,6 +8674,7 @@
         "module-alias": "^2.2.2",
         "nano-pubsub": "^3.0.0",
         "nanoid": "^3.1.30",
+        "node-html-parser": "^6.1.13",
         "observable-callback": "^1.0.1",
         "oneline": "^1.0.3",
         "open": "^8.4.0",
@@ -8386,6 +8683,7 @@
         "pluralize-esm": "^9.0.2",
         "polished": "^4.2.2",
         "pretty-ms": "^7.0.1",
+        "quick-lru": "^5.1.1",
         "raf": "^3.4.1",
         "react-copy-to-clipboard": "^5.0.4",
         "react-fast-compare": "^3.2.0",
@@ -8393,7 +8691,7 @@
         "react-i18next": "^13.0.1",
         "react-is": "^18.2.0",
         "react-refractor": "^2.1.6",
-        "react-rx": "^2.1.3",
+        "react-rx": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "refractor": "^3.6.0",
         "resolve-from": "^5.0.0",
@@ -8405,7 +8703,6 @@
         "semver": "^7.3.5",
         "shallow-equals": "^1.0.0",
         "speakingurl": "^14.0.1",
-        "swr": "^2.2.5",
         "tar-fs": "^2.1.1",
         "tar-stream": "^3.1.7",
         "use-device-pixel-ratio": "^1.1.0",
@@ -8511,6 +8808,17 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sanity/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sanity/node_modules/react-is": {
@@ -9038,18 +9346,6 @@
       "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
       "peerDependencies": {
         "react": ">=17.0"
-      }
-    },
-    "node_modules/swr": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
-      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.39.0",
-    "@sanity/cli": "3.39.0",
-    "@sanity/vision": "3.39.0",
+    "sanity": "3.48.1",
+    "@sanity/cli": "3.48.1",
+    "@sanity/vision": "3.48.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "sanity"
   ],
   "dependencies": {
-    "sanity": "3.36.4",
-    "@sanity/cli": "3.36.4",
-    "@sanity/vision": "3.36.4",
+    "sanity": "3.39.0",
+    "@sanity/cli": "3.39.0",
+    "@sanity/vision": "3.39.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-icons": "5.3.0",


### PR DESCRIPTION
Kule features:
v3.39: planlagt publisering (scheduled publishing)
v3.40: kan sjå kvar andre redigerer i ei tekstblokk
v3.41: drag-n-drop av bilete i staden for berre "finn fil og last opp"
