### PR TITLE
Grupper avhengigheiter slik at dependabot oppdaterer dei samstundes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,13 @@ updates:
         patterns:
           - "sanity"
           - "@sanity/*"
+        update-types:
+          - "patch"
+          - "minor"
       react-dependencies:
         patterns:
           - "react"
           - "react-dom"
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      sanity-dependencies:
+        patterns:
+          - "sanity"
+          - "@sanity/*"
+      react-dependencies:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
Dette gjer at oppdateringar som må gå i takt over fleire pakkar held seg i takt. Bonus: færre dependabot-PR-ar vil feile i bygg-stadiet fordi dei lager mismatch mellom versjonar.

Skrur av dependabot-pr for major-versjonar for React og Sanity, desse vil vi uansett sjå over manuelt.